### PR TITLE
URL is left alone when it contains a protocol

### DIFF
--- a/src/Http/Middleware/HandleNotFound.php
+++ b/src/Http/Middleware/HandleNotFound.php
@@ -25,7 +25,12 @@ class HandleNotFound
         }
 
         try {
-            $url = Str::start($request->path(), '/');
+            $url = $request->path();
+
+            if (! preg_match('/.*:\/\/.*/', $request->path()) ) {
+              $url = Str::start($request->path(), '/');
+            }
+            
             $error = $this->createError($request, $url);
 
             $this->cachedRedirects = Cache::get('statamic.redirect.redirects', []);


### PR DESCRIPTION
The URL is now left alone if it contains a `://`, which will assume that there's a protocol prefixed to the URL, like `http://` or `https://`.

I thought it would be better to do it this way since we never know what specific protocol an external link could be redirecting to, so this should also support unexpected things... like the `slack://` URI scheme for instance (ref: https://api.slack.com/reference/deep-linking).