### PR TITLE
Fix error when updating addon

### DIFF
--- a/src/UpdateScripts/ClearErrors.php
+++ b/src/UpdateScripts/ClearErrors.php
@@ -2,7 +2,7 @@
 
 namespace Rias\StatamicRedirect\UpdateScripts;
 
-use Statamic\Facades\File;
+use Illuminate\Support\Facades\File;
 use Statamic\Facades\Stache;
 use Statamic\UpdateScripts\UpdateScript;
 


### PR DESCRIPTION
At the end of `composer update`, one of this addon's upgrade scripts ran and caused this error:

![image](https://user-images.githubusercontent.com/19637309/149506684-8dafdd1b-c32f-415c-8b8c-5ecbe4454b27.png)

I had a look and it was as simple as using the Illuminate File facade, rather than Statamic's File facade. I would have presumed Statamic's one would just inherit the Illuminate one but it doesn't look like it 🤷‍♂️ 