### PR TITLE
Changes the name of the redirect table migration to clear re-declaration error

### DIFF
--- a/src/RedirectServiceProvider.php
+++ b/src/RedirectServiceProvider.php
@@ -91,7 +91,7 @@ class RedirectServiceProvider extends AddonServiceProvider
         if ($this->app->runningInConsole()) {
             if (! class_exists('CreateRedirectTables')) {
                 $this->publishes([
-                    __DIR__ . '/../database/migrations/create_redirect_tables.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_settings_table.php'),
+                    __DIR__ . '/../database/migrations/create_redirect_tables.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_redirect_tables.php'),
                 ], 'migrations');
             }
         }


### PR DESCRIPTION
In the current version ([1.10.3](https://github.com/riasvdv/statamic-redirect/releases/tag/1.10.3)), I attempted to run the database migrations after publishing the necessary migration stubs. In doing so, I received the following error:

```php
 Whoops\Exception\ErrorException

  Cannot declare class CreateRedirectTables, because the name is already in use

  at database/migrations/2022_01_19_142039_create_settings_table.php:7
      3▕ use Illuminate\Database\Migrations\Migration;
      4▕ use Illuminate\Database\Schema\Blueprint;
      5▕ use Illuminate\Support\Facades\Schema;
      6▕
  ➜   7▕ class CreateRedirectTables extends Migration
      8▕ {
      9▕     public function up()
     10▕     {
     11▕         Schema::create('redirects', function (Blueprint $table): void {

      +1 vendor frames
  2   [internal]:0
      Whoops\Run::handleShutdown()
```

This appears to be because the vendor published migration file has a different class name than the filename, and Laravel "pukes" on it. This pull request changes the name of the published migration file to clear the error.