### PR TITLE
Changed migration to set lastSeenAt and timestamp as integer

### DIFF
--- a/database/migrations/create_redirect_tables.php.stub
+++ b/database/migrations/create_redirect_tables.php.stub
@@ -14,7 +14,7 @@ class CreateRedirectTables extends Migration
             $table->string('url')->index();
             $table->boolean('handled')->default(false);
             $table->string('handledDestination')->nullable();
-            $table->dateTime('lastSeenAt')->nullable()->index();
+            $table->integer('lastSeenAt')->nullable()->index();
             $table->integer('hitsCount')->nullable();
         });
 
@@ -27,7 +27,7 @@ class CreateRedirectTables extends Migration
                 ->cascadeOnDelete();
 
             $table->json('data');
-            $table->timestamp('timestamp');
+            $table->integer('timestamp');
         });
     }
 }


### PR DESCRIPTION
Changed the migration to make `lastSeenAt` & `timestamp` into integers. The reason is that mysql timestamps aren't unix timestamps.
This should fix issue #52 
