### PR TITLE
Re-added support for Statamic 3.2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,6 @@ jobs:
             testbench: ^7.0
         exclude:
           - statamic: 3.2.*
-            testbench: ^5.20
             php: 8.1
           - statamic: 3.3.*
             php: 7.4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,12 +8,25 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: true
       matrix:
-        php: [8.0, 8.1]
-        statamic: [3.3.*]
+        php: [7.4, 8.0, 8.1]
+        statamic: [3.2.*, 3.3.*]
         include:
+          - statamic: 3.2.*
+            testbench: ^5.20
+          - statamic: 3.2.*
+            testbench: ^6.23
           - statamic: 3.3.*
-            testbench: 7.*
+            testbench: ^6.23
+          - statamic: 3.3.*
+            testbench: ^7.0
+        exclude:
+          - statamic: 3.2.*
+            testbench: ^5.20
+            php: 8.1
+          - statamic: 3.3.*
+            php: 7.4
 
     name: PHP ${{ matrix.php }} - Statamic ${{ matrix.statamic }}
     

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
-.DS_Store
-node_modules
+.DS_*
 .env
-composer.lock
+/.idea
+/.php_cs.cache
+/.php-cs-fixer.cache
+/.phpunit.result.cache
+/composer.lock
+/tests/_reports
 /vendor
 mix-manifest.json
-.php_cs.cache
-.php-cs-fixer.cache
+node_modules

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,16 @@
 {
     "name": "rias/statamic-redirect",
+    "require": {
+        "ext-json": "*",
+        "php": "^7.4|^8.0",
+        "spatie/simple-excel": "^1.13",
+        "statamic/cms": "^3.2"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.8",
+        "orchestra/testbench": "^5.0|^6.0|^7.0",
+        "phpunit/phpunit": "^9.3"
+    },
     "autoload": {
         "psr-4": {
             "Rias\\StatamicRedirect\\": "src"
@@ -10,15 +21,11 @@
             "Rias\\StatamicRedirect\\Tests\\": "tests"
         }
     },
-    "require": {
-        "ext-json": "*",
-        "php": "^8.0",
-        "statamic/cms": "^3.3",
-        "spatie/simple-excel": "^1.9"
-    },
-    "require-dev": {
-        "orchestra/testbench": "^5.0|^6.0",
-        "phpunit/phpunit": "^9.3"
+    "scripts": {
+        "lint": "php-cs-fixer fix --verbose --dry-run --diff",
+        "lint:fix": "php-cs-fixer fix --verbose --diff",
+        "test": "phpunit",
+        "test:coverage": "phpdbg -qrr vendor/bin/phpunit --color --coverage-html tests/_reports"
     },
     "extra": {
         "statamic": {

--- a/src/Controllers/ImportRedirectsController.php
+++ b/src/Controllers/ImportRedirectsController.php
@@ -32,11 +32,9 @@ class ImportRedirectsController
 
         /** @var \Illuminate\Http\UploadedFile $file */
         $file = $request->file('file');
-        $delimiter = request('delimiter', ',');
+        $delimiter = $request->input('delimiter', ',');
 
-        $extension = in_array($file->extension(), ['csv', 'txt'])
-            ? 'csv'
-            : $file->extension();
+        $extension = with($file->extension(), fn ($ext) => $ext === 'txt' ? 'csv' : $ext);
 
         $reader = SimpleExcelReader::create($file->getRealPath(), $extension)
             ->useDelimiter($delimiter);

--- a/src/Data/Concerns/TracksQueriedRelations.php
+++ b/src/Data/Concerns/TracksQueriedRelations.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rias\StatamicRedirect\Data\Concerns;
+
+/**
+ * Backport of `Statamic\Data\TracksQueriedRelations` to support Statamic 3.2.
+ */
+trait TracksQueriedRelations
+{
+    protected $selectedQueryRelations = [];
+
+    public function selectedQueryRelations($relations)
+    {
+        $this->selectedQueryRelations = $relations;
+
+        return $this;
+    }
+}

--- a/src/Data/Redirect.php
+++ b/src/Data/Redirect.php
@@ -3,12 +3,12 @@
 namespace Rias\StatamicRedirect\Data;
 
 use Illuminate\Support\Str;
+use Rias\StatamicRedirect\Data\Concerns\TracksQueriedRelations;
 use Rias\StatamicRedirect\Enums\MatchTypeEnum;
 use Rias\StatamicRedirect\Stache\Redirects\RedirectQueryBuilder;
 use Statamic\Data\DataCollection;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Data\TracksQueriedColumns;
-use Statamic\Data\TracksQueriedRelations;
 use Statamic\Facades\Stache;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 


### PR DESCRIPTION
Changes:
- Updated Github workflow with Statamic 3.2 & Laravel 7/8 tests
- Updated `composer.json` to allow PHP 7.4 and Statamic 3.2 - also bumped `spatie/simple-excel` to latest supported verison for PHP 7.4
- Updated `.gitignore`
- Minor adjustments to file extension detection for import
- Backported `Statamic\Data\TracksQueriedRelations` to support Statamic 3.2