### PR TITLE
Saving redirect locale in Store.

### DIFF
--- a/src/Data/Redirect.php
+++ b/src/Data/Redirect.php
@@ -139,6 +139,14 @@ class Redirect implements Localization
             ->args(func_get_args());
     }
 
+    public function setLocaleFromFilePath($path)
+    {
+        $explodedPath = explode('/', $path);
+        $locale = $explodedPath[count($explodedPath) - 2]; // locale is 2nd last path segment
+
+        return $this->locale($locale);
+    }
+
     public function site()
     {
         return Site::get($this->locale());

--- a/src/Stache/Redirects/RedirectStore.php
+++ b/src/Stache/Redirects/RedirectStore.php
@@ -34,6 +34,7 @@ class RedirectStore extends BasicStore
             ->type(array_pull($data, 'type'))
             ->matchType(array_pull($data, 'match_type'))
             ->enabled(array_pull($data, 'enabled'))
+            ->setLocaleFromFilePath($path)
             ->initialPath($path);
 
         if (isset($idGenerated)) {


### PR DESCRIPTION
Hi.
I had a problem with multisite Statamic configuration on multiple domains. I noticed several issues:
- redirects on frontend for different sites but default don't work
- filtering in CP by default (first) Site shows all redirects
- filtering in CP by different site (not default) gives no records.

It seemed that Redirect `locale` is not save in Stache, so queries by locale didn't worked. My fix simply adds saving locale to Store. 