### PR TITLE
Respect enable config

### DIFF
--- a/src/Listeners/CacheOldUri.php
+++ b/src/Listeners/CacheOldUri.php
@@ -10,6 +10,10 @@ class CacheOldUri
 {
     public function handle(EntrySaving $entrySaving)
     {
+        if (! config('statamic.redirect.enable', true)) {
+            return;
+        }
+        
         $entry = Entry::find($entrySaving->entry->id());
 
         if (! $entry || ! $uri = $entry->uri()) {

--- a/src/Listeners/CreateRedirect.php
+++ b/src/Listeners/CreateRedirect.php
@@ -11,6 +11,10 @@ class CreateRedirect
 {
     public function handle(EntrySaved $entrySaved)
     {
+        if (! config('statamic.redirect.enable', true)) {
+            return;
+        }
+
         /** @var \Statamic\Entries\Entry $entry */
         $entry = $entrySaved->entry;
 


### PR DESCRIPTION
Hi

I'm using your addon in a project with over 5000 entries in multiple collections. As we use Statamic only headless, we only need the manage aspect of this addon and all the rest should be disabled.

In my case, redirects would be deleted but not be recreated (I want none of these two features).

As there is an option to disable the whole thing, I think that the Listeners also should respect this configuration.

This is what this PR does.