### PR TITLE
Add labels to permissions

### DIFF
--- a/src/RedirectServiceProvider.php
+++ b/src/RedirectServiceProvider.php
@@ -193,12 +193,16 @@ class RedirectServiceProvider extends AddonServiceProvider
     {
         Permission::group('redirect', 'Redirects', function () {
             Permission::register('view redirects', function ($permission) {
-                $permission->children([
-                    Permission::make('edit redirects')->children([
-                        Permission::make('create redirects'),
-                        Permission::make('delete redirects'),
-                    ]),
-                ]);
+                $permission
+                    ->label('View Redirects')
+                    ->children([
+                        Permission::make('edit redirects')
+                            ->label('Edit Redirects')
+                            ->children([
+                                Permission::make('create redirects')->label('Create Redirects'),
+                                Permission::make('delete redirects')->label('Delete Redirects'),
+                            ]),
+                    ]);
             });
         });
 


### PR DESCRIPTION
This pull request makes a small improvement - it adds labels to the permissions added by this addon. Instead of them all being lowercase in the CP, they're a bit friendlier:

![image](https://user-images.githubusercontent.com/19637309/210752149-85c5ae71-6e44-4eeb-ad77-427eb5048fdc.png)
