### PR TITLE
add delete_entry_conflicting_redirects config setting

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -43,6 +43,10 @@ By default, Statamic Redirect will also keep individual hits for each error, you
 
 By default, Statamic Redirect will create redirects when the URI of an entry changes. You can disable this by setting the `create_entry_redirects` config value to `false`.
 
+### Deleting entry conflicting redirects
+
+By default, Statamic Redirect will delete redirects when a saved entry's URI conflicts with the redirect. You can disable this by setting the `delete_entry_conflicting_redirects` config value to `false`.
+
 ### Cleaning errors
 
 The amount of errors can grow quickly, Statamic Redirect includes a scheduled command that by default cleans up errors older than 1 month.

--- a/config/redirect.php
+++ b/config/redirect.php
@@ -13,6 +13,12 @@ return [
     'create_entry_redirects' => env('REDIRECT_AUTO_CREATE', true),
 
     /**
+     * Controls whether Redirect automatically deletes conflicting
+     * redirects when an entry is saved.
+     */
+    'delete_entry_conflicting_redirects' => env('REDIRECT_DELETE_CONFLICTS', true),
+
+    /**
      * Controls whether Redirect logs 404 errors
      */
     'log_errors' => env('REDIRECT_LOG_ERRORS', true),

--- a/src/Listeners/CreateRedirect.php
+++ b/src/Listeners/CreateRedirect.php
@@ -22,7 +22,7 @@ class CreateRedirect
          * If we have a redirect with a source of the
          * NEW uri we should remove this redirect.
          */
-        if ($entry->uri() && $entry->published() && $existingRedirect = Redirect::findByUrl($entry->locale(), $entry->uri())) {
+        if (config('statamic.redirect.delete_entry_conflicting_redirects', true) && $entry->uri() && $entry->published() && $existingRedirect = Redirect::findByUrl($entry->locale(), $entry->uri())) {
             $existingRedirect->delete();
         }
 


### PR DESCRIPTION
This adds a config setting to bypass the automatic deleting of redirects which would conflict with entry URIs. See #117. I've also had issues where `Redirect::findByUrl` matched entry URI `/foobar/abc123` to regex redirect `/abc123(.*)` and deleted the redirect — so really need a way to at least bypass this.