### PR TITLE
Switch to using a repository & facade for Redirect, add eloquent support

### DIFF
--- a/config/redirect.php
+++ b/config/redirect.php
@@ -63,4 +63,11 @@ return [
      * not be inside the usual content/redirects folder
      */
     'redirect_store' => base_path('content/redirects'),
+    
+    /*
+     * Customise the redirect repository you want to use for data
+     * storage. Change to \Rias\StatamicRedirect\Eloquent\Redirects\RedirectRepository::class
+     * for eloquent storage, or create your own custom repository
+     */
+    'redirect_repository' => \Rias\StatamicRedirect\Stache\Redirects\RedirectRepository::class,
 ];

--- a/config/redirect.php
+++ b/config/redirect.php
@@ -69,5 +69,5 @@ return [
      * storage. Change to \Rias\StatamicRedirect\Eloquent\Redirects\RedirectRepository::class
      * for eloquent storage, or create your own custom repository
      */
-    'redirect_repository' => \Rias\StatamicRedirect\Eloquent\Redirects\RedirectRepository::class,
+    'redirect_repository' => \Rias\StatamicRedirect\Stache\Redirects\RedirectRepository::class,
 ];

--- a/config/redirect.php
+++ b/config/redirect.php
@@ -69,5 +69,5 @@ return [
      * storage. Change to \Rias\StatamicRedirect\Eloquent\Redirects\RedirectRepository::class
      * for eloquent storage, or create your own custom repository
      */
-    'redirect_repository' => \Rias\StatamicRedirect\Stache\Redirects\RedirectRepository::class,
+    'redirect_repository' => \Rias\StatamicRedirect\Eloquent\Redirects\RedirectRepository::class,
 ];

--- a/database/migrations/create_eloquent_redirect_table.php.stub
+++ b/database/migrations/create_eloquent_redirect_table.php.stub
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateEloquentRedirectTable extends Migration
+{
+    public function up()
+    {
+        Schema::connection(config('statamic.redirect.connection', 'redirect'))
+            ->create('redirects', function (Blueprint $table): void {
+                $table->uuid('id')->unique()->index();
+                $table->string('source')->index();
+                $table->string('destination');
+                $table->char('match_type', 10);
+                $table->char('type', 10);
+                $table->string('locale');
+                $table->integer('order')->nullable();
+                $table->boolean('enabled');
+                $table->timestamps();
+            });
+    }
+
+    public function down()
+    {
+        Schema::connection(config('statamic.redirect.connection', 'redirect'))
+            ->dropIfExists('redirects');
+    }
+}

--- a/src/Contracts/Redirect.php
+++ b/src/Contracts/Redirect.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rias\StatamicRedirect\Contracts;
+
+interface Redirect
+{
+}

--- a/src/Contracts/RedirectQueryBuilder.php
+++ b/src/Contracts/RedirectQueryBuilder.php
@@ -1,0 +1,8 @@
+<?php
+
+
+namespace Rias\StatamicRedirect\Contracts;
+
+interface RedirectQueryBuilder
+{
+}

--- a/src/Contracts/RedirectRepository.php
+++ b/src/Contracts/RedirectRepository.php
@@ -9,7 +9,7 @@ interface RedirectRepository
 
     public function find($id);
 
-    public function findByUrl(string $url);
+    public function findByUrl(string $siteHandle, string $url);
 
     public function make();
 

--- a/src/Controllers/Api/RedirectController.php
+++ b/src/Controllers/Api/RedirectController.php
@@ -3,9 +3,9 @@
 namespace Rias\StatamicRedirect\Controllers\Api;
 
 use Illuminate\Http\JsonResponse;
-use Rias\StatamicRedirect\Data\Redirect;
+use Rias\StatamicRedirect\Contracts\RedirectQueryBuilder;
+use Rias\StatamicRedirect\Facades\Redirect;
 use Rias\StatamicRedirect\Http\Resources\RedirectsCollection;
-use Rias\StatamicRedirect\Stache\Redirects\RedirectQueryBuilder;
 use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 

--- a/src/Controllers/ImportRedirectsController.php
+++ b/src/Controllers/ImportRedirectsController.php
@@ -4,7 +4,7 @@ namespace Rias\StatamicRedirect\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
-use Rias\StatamicRedirect\Data\Redirect;
+use Rias\StatamicRedirect\Facades\Redirect;
 use Spatie\SimpleExcel\SimpleExcelReader;
 use Statamic\Facades\User;
 

--- a/src/Controllers/RedirectController.php
+++ b/src/Controllers/RedirectController.php
@@ -5,7 +5,7 @@ namespace Rias\StatamicRedirect\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Rias\StatamicRedirect\Blueprints\RedirectBlueprint;
-use Rias\StatamicRedirect\Data\Redirect;
+use Rias\StatamicRedirect\Facades\Redirect;
 use Rias\StatamicRedirect\Http\Resources\ListedRedirect;
 use Statamic\Facades\Scope;
 use Statamic\Facades\Site;

--- a/src/Data/Redirect.php
+++ b/src/Data/Redirect.php
@@ -2,20 +2,18 @@
 
 namespace Rias\StatamicRedirect\Data;
 
-use Illuminate\Support\Str;
+use Rias\StatamicRedirect\Contracts\Redirect as RedirectContract;
 use Rias\StatamicRedirect\Data\Concerns\TracksQueriedRelations;
 use Rias\StatamicRedirect\Enums\MatchTypeEnum;
 use Rias\StatamicRedirect\Events\RedirectSaved;
-use Rias\StatamicRedirect\Stache\Redirects\RedirectQueryBuilder;
 use Statamic\Contracts\Data\Localization;
-use Statamic\Data\DataCollection;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Data\TracksQueriedColumns;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class Redirect implements Localization
+class Redirect implements Localization, RedirectContract
 {
     use FluentlyGetsAndSets;
     use ExistsAsFile;
@@ -42,61 +40,6 @@ class Redirect implements Localization
 
     /** @var string */
     protected $matchType = MatchTypeEnum::EXACT;
-
-    public static function make()
-    {
-        return new self();
-    }
-
-    public static function query(): RedirectQueryBuilder
-    {
-        return (new RedirectQueryBuilder(Stache::store('redirects')));
-    }
-
-    public static function all(): DataCollection
-    {
-        return self::query()->get();
-    }
-
-    public static function find($id): ?self
-    {
-        return self::query()->where('id', $id)->first();
-    }
-
-    public static function findByUrl(string $siteHandle, string $url): ?Redirect
-    {
-        return self::query()
-            ->where('enabled', true)
-            ->where('locale', $siteHandle)
-            ->orderBy('order')
-            ->get()
-            ->map(function (Redirect $redirect) use ($url) {
-                if ($redirect->matchType() === MatchTypeEnum::REGEX) {
-                    $source = str_replace('/', "\/", $redirect->source());
-                    $matchRegEx = '`'.$source.'`i';
-
-                    if (preg_match($matchRegEx, $url) === 1) {
-                        $redirect->destination(preg_replace(
-                            $matchRegEx,
-                            $redirect->destination(),
-                            $url
-                        ));
-
-                        return $redirect;
-                    }
-                }
-
-                if (strcmp(Str::start($redirect->source(), '/'), Str::start($url, '/')) === 0
-                    || strcmp(Str::start($redirect->source(), '/'), Str::start($url . '/', '/')) === 0
-                ) {
-                    return $redirect;
-                }
-
-                return null;
-            })
-            ->filter()
-            ->first();
-    }
 
     public function id($id = null)
     {

--- a/src/Data/Redirect.php
+++ b/src/Data/Redirect.php
@@ -5,7 +5,7 @@ namespace Rias\StatamicRedirect\Data;
 use Rias\StatamicRedirect\Contracts\Redirect as RedirectContract;
 use Rias\StatamicRedirect\Data\Concerns\TracksQueriedRelations;
 use Rias\StatamicRedirect\Enums\MatchTypeEnum;
-use Rias\StatamicRedirect\Events\RedirectSaved;
+use Rias\StatamicRedirect\Facades\Redirect as RedirectFacade;
 use Statamic\Contracts\Data\Localization;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Data\TracksQueriedColumns;
@@ -114,22 +114,12 @@ class Redirect implements Localization, RedirectContract
 
     public function save()
     {
-        if (! $this->id()) {
-            $this->id(Stache::generateId());
-        }
-
-        Stache::store('redirects')->save($this);
-
-        event(new RedirectSaved($this));
-
-        return true;
+        return RedirectFacade::save($this);
     }
 
     public function delete()
     {
-        Stache::store('redirects')->delete($this);
-
-        return true;
+        return RedirectFacade::delete($this);
     }
 
     public function fileData()

--- a/src/Eloquent/Redirects/RedirectModel.php
+++ b/src/Eloquent/Redirects/RedirectModel.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rias\StatamicRedirect\Eloquent\Redirects;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+
+class RedirectModel extends Model
+{
+    use HasUuids;
+    
+    protected $guarded = [];
+
+    protected $casts = [];
+    
+    protected $table = 'redirects';
+
+    public function getConnectionName()
+    {
+        return config('statamic.redirect.connection', 'redirect');
+    }
+}

--- a/src/Eloquent/Redirects/RedirectQueryBuilder.php
+++ b/src/Eloquent/Redirects/RedirectQueryBuilder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rias\StatamicRedirect\Eloquent\Redirects;
+
+use Rias\StatamicRedirect\Contracts\RedirectQueryBuilder as Contract;
+use Statamic\Data\DataCollection;
+use Statamic\Query\EloquentQueryBuilder;
+
+class RedirectQueryBuilder extends EloquentQueryBuilder implements Contract
+{
+    protected function transform($items, $columns = [])
+    {
+        return DataCollection::make($items)->map(function ($model) use ($columns) {
+            return RedirectRepository::fromModel($model);
+        });
+    }
+}

--- a/src/Eloquent/Redirects/RedirectRepository.php
+++ b/src/Eloquent/Redirects/RedirectRepository.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Rias\StatamicRedirect\Eloquent\Redirects;
+
+use Illuminate\Database\Eloquent\Model;
+use Rias\StatamicRedirect\Contracts\RedirectRepository as RepositoryContract;
+use Rias\StatamicRedirect\Data\Redirect;
+use Rias\StatamicRedirect\Enums\MatchTypeEnum;
+use Statamic\Data\DataCollection;
+use Statamic\Stache\Stache;
+use Statamic\Support\Str;
+
+class RedirectRepository implements RepositoryContract
+{
+    protected $stache;
+
+    public function __construct(Stache $stache)
+    {
+        $this->stache = $stache;
+    }
+
+    public function all(): DataCollection
+    {
+        return $this->query()->get();
+    }
+
+    public function find($id): ?Redirect
+    {
+        return $this->query()->where('id', $id)->first();
+    }
+
+    public function findByUrl(string $siteHandle, string $url): ?Redirect
+    {
+        return $this->query()
+            ->where('enabled', true)
+            ->where('locale', $siteHandle)
+            ->orderBy('order')
+            ->get()
+            ->map(function (Redirect $redirect) use ($url) {
+                if ($redirect->matchType() === MatchTypeEnum::REGEX) {
+                    $source = str_replace('/', "\/", $redirect->source());
+                    $matchRegEx = '`'.$source.'`i';
+
+                    if (preg_match($matchRegEx, $url) === 1) {
+                        $redirect->destination(preg_replace(
+                            $matchRegEx,
+                            $redirect->destination(),
+                            $url
+                        ));
+
+                        return $redirect;
+                    }
+                }
+
+                if (strcmp(Str::start($redirect->source(), '/'), Str::start($url, '/')) === 0
+                    || strcmp(Str::start($redirect->source(), '/'), Str::start($url . '/', '/')) === 0
+                ) {
+                    return $redirect;
+                }
+
+                return null;
+            })
+            ->filter()
+            ->first();
+    }
+
+    public function save($redirect)
+    {
+        if (! $redirect->id()) {
+            $redirect->id($this->stache->generateId());
+        }
+
+        $this->toModel($redirect)->save();
+    }
+
+    public function delete($entry)
+    {
+        $this->toModel($redirect)?->delete();
+    }
+
+    public function query()
+    {
+        return new RedirectQueryBuilder(RedirectModel::query());
+    }
+
+    public function make(): Redirect
+    {
+        return new Redirect();
+    }
+    
+    public static function fromModel(Model $model)
+    {
+        return (new Redirect)
+            ->id($model->id)
+            ->source($model->source)
+            ->destination($model->destination)
+            ->type($model->type)
+            ->matchType($model->match_type)
+            ->enabled($model->enabled)
+            ->order($model->order)
+            ->locale($model->locale);
+    }
+    
+    private function toModel(Redirect $redirect)
+    {
+        return RedirectModel::firstOrNew([
+            'id' => $redirect->id()
+        ], [
+            'source' => $redirect->source(),
+            'destination' => $redirect->destination(),
+            'match_type' => $redirect->matchType(),
+            'type' => $redirect->type(),
+            'enabled' => $redirect->enabled(),
+            'order' => $redirect->order(),
+            'locale' => $redirect->locale(),
+        ]);  
+    }
+}

--- a/src/Exporters/CsvExporter.php
+++ b/src/Exporters/CsvExporter.php
@@ -3,7 +3,7 @@
 namespace Rias\StatamicRedirect\Exporters;
 
 use League\Csv\Writer;
-use Rias\StatamicRedirect\Data\Redirect;
+use Rias\StatamicRedirect\Facades\Redirect;
 use SplTempFileObject;
 use Statamic\Forms\Exporters\AbstractExporter;
 

--- a/src/Exporters/JsonExporter.php
+++ b/src/Exporters/JsonExporter.php
@@ -2,7 +2,7 @@
 
 namespace Rias\StatamicRedirect\Exporters;
 
-use Rias\StatamicRedirect\Data\Redirect;
+use Rias\StatamicRedirect\Facades\Redirect;
 use Statamic\Forms\Exporters\AbstractExporter;
 
 class JsonExporter extends AbstractExporter

--- a/src/Facades/Redirect.php
+++ b/src/Facades/Redirect.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rias\StatamicRedirect\Facades;
+
+use Rias\StatamicRedirect\Contracts\RedirectRepository;
+use Illuminate\Support\Facades\Facade;
+
+class Redirect extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return RedirectRepository::class;
+    }
+}

--- a/src/Http/Middleware/HandleNotFound.php
+++ b/src/Http/Middleware/HandleNotFound.php
@@ -5,8 +5,9 @@ namespace Rias\StatamicRedirect\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
+use Rias\StatamicRedirect\Contracts\Redirect as RedirectContract;
 use Rias\StatamicRedirect\Data\Error;
-use Rias\StatamicRedirect\Data\Redirect;
+use Rias\StatamicRedirect\Facades\Redirect;
 use Rias\StatamicRedirect\Jobs\CleanErrorsJob;
 use Statamic\Facades\Site;
 use Statamic\Support\Str;
@@ -25,7 +26,7 @@ class HandleNotFound
         if ($response->status() !== 404 || ! config('statamic.redirect.enable', true)) {
             return $response;
         }
-
+        
         try {
             $site = Site::findByUrl($request->url()) ?? Site::default();
 
@@ -122,7 +123,7 @@ class HandleNotFound
      * @param \Rias\StatamicRedirect\Data\Redirect $redirect
      * @param string $url
      */
-    private function cacheNewRedirect(\Statamic\Sites\Site $site, Redirect $redirect, string $url): void
+    private function cacheNewRedirect(\Statamic\Sites\Site $site, RedirectContract $redirect, string $url): void
     {
         $this->cachedRedirects[$site->handle()][$url] = [
             'destination' => $redirect->destination(),

--- a/src/Listeners/CreateRedirect.php
+++ b/src/Listeners/CreateRedirect.php
@@ -3,7 +3,7 @@
 namespace Rias\StatamicRedirect\Listeners;
 
 use Illuminate\Support\Facades\Cache;
-use Rias\StatamicRedirect\Data\Redirect;
+use Rias\StatamicRedirect\Facades\Redirect;
 use Rias\StatamicRedirect\Enums\MatchTypeEnum;
 use Statamic\Events\EntrySaved;
 

--- a/src/RedirectServiceProvider.php
+++ b/src/RedirectServiceProvider.php
@@ -90,6 +90,12 @@ class RedirectServiceProvider extends AddonServiceProvider
                     __DIR__ . '/../database/migrations/create_redirect_tables.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_redirect_tables.php'),
                 ], 'migrations');
             }
+            
+            if (! class_exists('CreateEloquentRedirectTable')) {
+                $this->publishes([
+                    __DIR__ . '/../database/migrations/create_eloquent_redirect_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_eloquent_redirect_table.php'),
+                ], 'redirect-eloquent-migrations');
+            }
         }
 
         Statamic::booted(function () {

--- a/src/Stache/Redirects/RedirectQueryBuilder.php
+++ b/src/Stache/Redirects/RedirectQueryBuilder.php
@@ -2,10 +2,11 @@
 
 namespace Rias\StatamicRedirect\Stache\Redirects;
 
+use Rias\StatamicRedirect\Contracts\RedirectQueryBuilder as Contract;
 use Statamic\Data\DataCollection;
 use Statamic\Stache\Query\Builder;
 
-class RedirectQueryBuilder extends Builder
+class RedirectQueryBuilder extends Builder implements Contract
 {
     protected function getFilteredKeys()
     {

--- a/src/Stache/Redirects/RedirectRepository.php
+++ b/src/Stache/Redirects/RedirectRepository.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Rias\StatamicRedirect\Stache\Redirects;
+
+use Rias\StatamicRedirect\Contracts\RedirectRepository as RepositoryContract;
+use Rias\StatamicRedirect\Data\Redirect;
+use Rias\StatamicRedirect\Enums\MatchTypeEnum;
+use Statamic\Data\DataCollection;
+use Statamic\Stache\Stache;
+use Statamic\Support\Str;
+
+class RedirectRepository implements RepositoryContract
+{
+    /** @var \Statamic\Stache\Stache */
+    protected $stache;
+
+    /** @var \Statamic\Stache\Stores\Store */
+    protected $store;
+
+    public function __construct(Stache $stache)
+    {
+        $this->stache = $stache;
+        $this->store = $stache->store('redirects');
+    }
+
+    public function all(): DataCollection
+    {
+        return $this->query()->get();
+    }
+
+    public function find($id): ?Redirect
+    {
+        return $this->query()->where('id', $id)->first();
+    }
+
+    public function findByUrl(string $siteHandle, string $url): ?Redirect
+    {
+        return $this->query()
+            ->where('enabled', true)
+            ->where('locale', $siteHandle)
+            ->orderBy('order')
+            ->get()
+            ->map(function (Redirect $redirect) use ($url) {
+                if ($redirect->matchType() === MatchTypeEnum::REGEX) {
+                    $source = str_replace('/', "\/", $redirect->source());
+                    $matchRegEx = '`'.$source.'`i';
+
+                    if (preg_match($matchRegEx, $url) === 1) {
+                        $redirect->destination(preg_replace(
+                            $matchRegEx,
+                            $redirect->destination(),
+                            $url
+                        ));
+
+                        return $redirect;
+                    }
+                }
+
+                if (strcmp(Str::start($redirect->source(), '/'), Str::start($url, '/')) === 0
+                    || strcmp(Str::start($redirect->source(), '/'), Str::start($url . '/', '/')) === 0
+                ) {
+                    return $redirect;
+                }
+
+                return null;
+            })
+            ->filter()
+            ->first();
+    }
+
+    public function save($redirect)
+    {
+        if (! $redirect->id()) {
+            $redirect->id($this->stache->generateId());
+        }
+
+        $this->store->save($redirect);
+    }
+
+    public function delete($entry)
+    {
+        $this->store->delete($entry);
+    }
+
+    public function query()
+    {
+        return new RedirectQueryBuilder($this->store);
+    }
+
+    public function make(): Redirect
+    {
+        return new Redirect();
+    }
+}

--- a/src/Stache/Redirects/RedirectRepository.php
+++ b/src/Stache/Redirects/RedirectRepository.php
@@ -5,7 +5,9 @@ namespace Rias\StatamicRedirect\Stache\Redirects;
 use Rias\StatamicRedirect\Contracts\RedirectRepository as RepositoryContract;
 use Rias\StatamicRedirect\Data\Redirect;
 use Rias\StatamicRedirect\Enums\MatchTypeEnum;
+use Rias\StatamicRedirect\Events\RedirectSaved;
 use Statamic\Data\DataCollection;
+use Statamic\Facades\Stache as StacheFacade;
 use Statamic\Stache\Stache;
 use Statamic\Support\Str;
 
@@ -71,15 +73,19 @@ class RedirectRepository implements RepositoryContract
     public function save($redirect)
     {
         if (! $redirect->id()) {
-            $redirect->id($this->stache->generateId());
+            $redirect->id(StacheFacade::generateId());
         }
 
-        $this->store->save($redirect);
+        StacheFacade::store('redirects')->save($redirect);
+
+        event(new RedirectSaved($redirect));
     }
 
-    public function delete($entry)
+    public function delete($redirect)
     {
-        $this->store->delete($entry);
+        StacheFacade::store('redirects')->delete($redirect);
+        
+        return true;
     }
 
     public function query()

--- a/src/Stache/Redirects/RedirectStore.php
+++ b/src/Stache/Redirects/RedirectStore.php
@@ -2,7 +2,7 @@
 
 namespace Rias\StatamicRedirect\Stache\Redirects;
 
-use Rias\StatamicRedirect\Data\Redirect;
+use Rias\StatamicRedirect\Facades\Redirect;
 use Statamic\Facades\YAML;
 use Statamic\Stache\Stores\BasicStore;
 use Symfony\Component\Finder\SplFileInfo;

--- a/tests/Feature/Controllers/ImportRedirectsControllerTest.php
+++ b/tests/Feature/Controllers/ImportRedirectsControllerTest.php
@@ -3,8 +3,9 @@
 namespace Rias\StatamicRedirect\Tests\Feature\Controllers;
 
 use Illuminate\Http\UploadedFile;
+use Rias\StatamicRedirect\Contracts\Redirect as RedirectContract;
 use Rias\StatamicRedirect\Controllers\ImportRedirectsController;
-use Rias\StatamicRedirect\Data\Redirect;
+use Rias\StatamicRedirect\Facades\Redirect;
 use Rias\StatamicRedirect\Tests\TestCase;
 
 class ImportRedirectsControllerTest extends TestCase
@@ -26,7 +27,7 @@ class ImportRedirectsControllerTest extends TestCase
         ])->assertRedirect()->assertSessionHas('success', 'Redirects imported successfully.');
 
         $this->assertEquals(1, Redirect::query()->count());
-        tap(Redirect::findByUrl(\Statamic\Facades\Site::default()->handle(), '/foo'), function (Redirect $redirect) {
+        tap(Redirect::findByUrl(\Statamic\Facades\Site::default()->handle(), '/foo'), function (RedirectContract $redirect) {
             $this->assertEquals('/bar', $redirect->destination());
             $this->assertEquals('302', $redirect->type());
             $this->assertEquals('exact', $redirect->matchType());
@@ -50,7 +51,7 @@ class ImportRedirectsControllerTest extends TestCase
         ])->assertRedirect()->assertSessionHas('success', 'Redirects imported successfully.');
 
         $this->assertEquals(1, Redirect::query()->count());
-        tap(Redirect::findByUrl('en', '/foo'), function (Redirect $redirect) {
+        tap(Redirect::findByUrl('en', '/foo'), function (RedirectContract $redirect) {
             $this->assertEquals('/bar', $redirect->destination());
             $this->assertEquals('302', $redirect->type());
             $this->assertEquals('exact', $redirect->matchType());
@@ -74,7 +75,7 @@ class ImportRedirectsControllerTest extends TestCase
         ])->assertRedirect()->assertSessionHas('success', 'Redirects imported successfully.');
 
         $this->assertEquals(1, Redirect::query()->count());
-        tap(Redirect::findByUrl(\Statamic\Facades\Site::default()->handle(), '/foo'), function (Redirect $redirect) {
+        tap(Redirect::findByUrl(\Statamic\Facades\Site::default()->handle(), '/foo'), function (RedirectContract $redirect) {
             $this->assertEquals('/bar', $redirect->destination());
             $this->assertEquals('302', $redirect->type());
             $this->assertEquals('exact', $redirect->matchType());
@@ -98,7 +99,7 @@ class ImportRedirectsControllerTest extends TestCase
         ])->assertRedirect()->assertSessionHas('success', "Redirects imported successfully. 4 rows skipped due to invalid data.");
 
         $this->assertEquals(1, Redirect::query()->count());
-        tap(Redirect::findByUrl(\Statamic\Facades\Site::default()->handle(), '/foo'), function (Redirect $redirect) {
+        tap(Redirect::findByUrl(\Statamic\Facades\Site::default()->handle(), '/foo'), function (RedirectContract $redirect) {
             $this->assertEquals('/bar', $redirect->destination());
             $this->assertEquals('302', $redirect->type());
             $this->assertEquals('exact', $redirect->matchType());

--- a/tests/Feature/Middleware/HandleNotFoundTest.php
+++ b/tests/Feature/Middleware/HandleNotFoundTest.php
@@ -6,8 +6,8 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
 use Rias\StatamicRedirect\Data\Error;
-use Rias\StatamicRedirect\Data\Redirect;
 use Rias\StatamicRedirect\Enums\MatchTypeEnum;
+use Rias\StatamicRedirect\Facades\Redirect;
 use Rias\StatamicRedirect\Http\Middleware\HandleNotFound;
 use Rias\StatamicRedirect\Tests\TestCase;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -111,13 +111,13 @@ class HandleNotFoundTest extends TestCase
      */
     public function it_handles_401_redirects()
     {
-        $this->withExceptionHandling();
+        //$this->withExceptionHandling();
 
         Redirect::make()
             ->source('/abc')
             ->type(410)
             ->save();
-
+            
         try {
             $this->middleware->handle(Request::create('/abc'), function () {
                 return (new Response('', 404));

--- a/tests/Feature/MoveRedirectsToDefaultSiteTest.php
+++ b/tests/Feature/MoveRedirectsToDefaultSiteTest.php
@@ -3,7 +3,7 @@
 namespace Rias\StatamicRedirect\Tests\Feature;
 
 use Illuminate\Support\Facades\File;
-use Rias\StatamicRedirect\Data\Redirect;
+use Rias\StatamicRedirect\Facades\Redirect;
 use Rias\StatamicRedirect\Tests\TestCase;
 use Rias\StatamicRedirect\UpdateScripts\MoveRedirectsToDefaultSite;
 use Statamic\Facades\Stache;

--- a/tests/Feature/RedirectTest.php
+++ b/tests/Feature/RedirectTest.php
@@ -3,8 +3,8 @@
 namespace Rias\StatamicRedirect\Tests\Feature;
 
 use Illuminate\Support\Facades\Event;
-use Rias\StatamicRedirect\Data\Redirect;
 use Rias\StatamicRedirect\Events\RedirectSaved;
+use Rias\StatamicRedirect\Facades\Redirect;
 use Rias\StatamicRedirect\Tests\TestCase;
 
 class RedirectTest extends TestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Rias\StatamicRedirect\Data\Error;
 use Rias\StatamicRedirect\Data\Hit;
-use Rias\StatamicRedirect\Data\Redirect;
+use Rias\StatamicRedirect\Facades\Redirect;
 use Statamic\Extend\Manifest;
 use Statamic\Facades\User;
 use Statamic\Statamic;


### PR DESCRIPTION
This PR adds eloquent support to the redirects.

To do this I've:
- Moved any calls to Data\Redirect to a facade (Facades\Redirect)
- Created a repository contract and query builder contract
- Created a stache repository and moved the save/delete/query/find methods from Data\Redirect to it
- Created eloquent repositories

Let me know if you need/want anything else to have this approved.

Closes https://github.com/riasvdv/statamic-redirect/issues/106