### PR TITLE
Support symfony http foundation steamed response

### DIFF
--- a/src/Http/Middleware/HandleNotFound.php
+++ b/src/Http/Middleware/HandleNotFound.php
@@ -22,7 +22,7 @@ class HandleNotFound
         /** @var \Illuminate\Http\Response $response */
         $response = $next($request);
 
-        if ($response->status() !== 404 || ! config('statamic.redirect.enable', true)) {
+        if ($response->getStatusCode() !== 404 || ! config('statamic.redirect.enable', true)) {
             return $response;
         }
 


### PR DESCRIPTION
Resolved error with steamed response: 

```
Error: Call to undefined method Symfony\Component\HttpFoundation\StreamedResponse::status()
```

Resolved #140 