### PR TITLE
Clear eloquent blink cache in cache old uri listener

### DIFF
--- a/src/Listeners/CacheOldUri.php
+++ b/src/Listeners/CacheOldUri.php
@@ -4,6 +4,7 @@ namespace Rias\StatamicRedirect\Listeners;
 
 use Illuminate\Support\Facades\Cache;
 use Statamic\Events\EntrySaving;
+use Statamic\Facades\Blink;
 use Statamic\Facades\Entry;
 
 class CacheOldUri
@@ -14,7 +15,10 @@ class CacheOldUri
             return;
         }
         
-        $entry = Entry::find($entrySaving->entry->id());
+        $id = $entrySaving->entry->id();
+        
+        Blink::forget('eloquent-entry-'.$id);
+        $entry = Entry::find($id);
 
         if (! $entry || ! $uri = $entry->uri()) {
             return;


### PR DESCRIPTION
As reported [over here](https://github.com/statamic/eloquent-driver/issues/219) there's an issue with eloquent redirects in that we do some aggressive caching which is tripping things up. The issue details the problem.

As a temporary measure until something better lands in core, this PR just clears the blink cache, which solves it.