### PR TITLE
Fix date error on error widget

### DIFF
--- a/resources/views/widgets/errors.blade.php
+++ b/resources/views/widgets/errors.blade.php
@@ -28,7 +28,7 @@
                             </div>
                         </td>
                         <td class="">
-                            <span>{{ Date::createFromTimestamp($error->lastSeenAt)->diffForHumans() }}</span>
+                            <span>{{ \Carbon\Carbon::createFromTimestamp($error->lastSeenAt)->diffForHumans() }}</span>
                         </td>
                         <th class="actions-column">
                             @if (! $error->handled)


### PR DESCRIPTION
The dashboard shows the following error when using the error-widget:

![CleanShot 2024-01-06 at 12 27 13@2x](https://github.com/riasvdv/statamic-redirect/assets/22601927/cc57fd9d-38db-462f-8ecb-151cff145b6d)

This PR solves this for us.