### PR TITLE
Rename `locale` to `site` on redirects table

### DIFF
--- a/database/migrations/create_eloquent_redirect_table.php.stub
+++ b/database/migrations/create_eloquent_redirect_table.php.stub
@@ -15,7 +15,7 @@ class CreateEloquentRedirectTable extends Migration
                 $table->string('destination');
                 $table->char('match_type', 10);
                 $table->char('type', 10);
-                $table->string('locale');
+                $table->string('site')->index();
                 $table->integer('order')->nullable();
                 $table->boolean('enabled');
                 $table->timestamps();

--- a/src/Blueprints/RedirectBlueprint.php
+++ b/src/Blueprints/RedirectBlueprint.php
@@ -26,7 +26,7 @@ class RedirectBlueprint extends Blueprint
                                     $existing = Redirect::query()
                                         ->where('source', $value)
                                         ->when(request()->route('id'), fn ($query) => $query->where('id', '!=', request()->route('id')))
-                                        ->where('site', Site::current()->handle())
+                                        ->where('locale', Site::current()->handle())
                                         ->count() > 0;
 
                                     if ($existing) {

--- a/src/Blueprints/RedirectBlueprint.php
+++ b/src/Blueprints/RedirectBlueprint.php
@@ -26,7 +26,7 @@ class RedirectBlueprint extends Blueprint
                                     $existing = Redirect::query()
                                         ->where('source', $value)
                                         ->when(request()->route('id'), fn ($query) => $query->where('id', '!=', request()->route('id')))
-                                        ->where('locale', Site::current()->handle())
+                                        ->where('site', Site::current()->handle())
                                         ->count() > 0;
 
                                     if ($existing) {

--- a/src/Eloquent/Redirects/RedirectRepository.php
+++ b/src/Eloquent/Redirects/RedirectRepository.php
@@ -33,7 +33,7 @@ class RedirectRepository implements RepositoryContract
     {
         return $this->query()
             ->where('enabled', true)
-            ->where('locale', $siteHandle)
+            ->where('site', $siteHandle)
             ->orderBy('order')
             ->get()
             ->map(function (Redirect $redirect) use ($url) {

--- a/src/Eloquent/Redirects/RedirectRepository.php
+++ b/src/Eloquent/Redirects/RedirectRepository.php
@@ -87,7 +87,7 @@ class RedirectRepository implements RepositoryContract
     {
         return new Redirect();
     }
-    
+
     public static function fromModel(Model $model)
     {
         return (new Redirect)
@@ -98,9 +98,9 @@ class RedirectRepository implements RepositoryContract
             ->matchType($model->match_type)
             ->enabled($model->enabled)
             ->order($model->order)
-            ->locale($model->locale);
+            ->locale($model->site);
     }
-    
+
     private function toModel(Redirect $redirect)
     {
         return RedirectModel::firstOrNew([
@@ -112,7 +112,7 @@ class RedirectRepository implements RepositoryContract
             'type' => $redirect->type(),
             'enabled' => $redirect->enabled(),
             'order' => $redirect->order(),
-            'locale' => $redirect->locale(),
+            'site' => $redirect->locale(),
         ]);
     }
 }

--- a/src/RedirectServiceProvider.php
+++ b/src/RedirectServiceProvider.php
@@ -20,6 +20,7 @@ use Rias\StatamicRedirect\Stache\Redirects\RedirectStore;
 use Rias\StatamicRedirect\UpdateScripts\AddHitsCount;
 use Rias\StatamicRedirect\UpdateScripts\ClearErrors;
 use Rias\StatamicRedirect\UpdateScripts\MoveRedirectsToDefaultSite;
+use Rias\StatamicRedirect\UpdateScripts\RenameLocaleToSiteOnRedirectsTable;
 use Rias\StatamicRedirect\Widgets\ErrorsLastDayWidget;
 use Rias\StatamicRedirect\Widgets\ErrorsLastMonthWidget;
 use Rias\StatamicRedirect\Widgets\ErrorsLastWeekWidget;
@@ -39,6 +40,7 @@ class RedirectServiceProvider extends AddonServiceProvider
         AddHitsCount::class,
         ClearErrors::class,
         MoveRedirectsToDefaultSite::class,
+        RenameLocaleToSiteOnRedirectsTable::class,
     ];
 
     protected $scripts = [
@@ -90,7 +92,7 @@ class RedirectServiceProvider extends AddonServiceProvider
                     __DIR__ . '/../database/migrations/create_redirect_tables.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_redirect_tables.php'),
                 ], 'migrations');
             }
-            
+
             if (! class_exists('CreateEloquentRedirectTable')) {
                 $this->publishes([
                     __DIR__ . '/../database/migrations/create_eloquent_redirect_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_eloquent_redirect_table.php'),

--- a/src/UpdateScripts/RenameLocaleToSiteOnRedirectsTable.php
+++ b/src/UpdateScripts/RenameLocaleToSiteOnRedirectsTable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rias\StatamicRedirect\UpdateScripts;
+
+use Illuminate\Support\Facades\Schema;
+use Statamic\UpdateScripts\UpdateScript;
+
+class RenameLocaleToSiteOnRedirectsTable extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return Schema::hasColumn('redirects', 'locale');
+    }
+
+    public function update()
+    {
+        Schema::table('redirects', function ($table) {
+            $table->renameColumn('locale', 'site');
+            $table->index(['site']);
+        });
+
+        $this->console()->info('Column renamed succesfully!');
+    }
+}


### PR DESCRIPTION
Advantages:
* More consistent with [statamic/eloquent-driver](https://github.com/statamic/eloquent-driver/tree/master).
* Fixes issue where eloquent-redirect could not be created because of validation rule in blueprint which queries based on a [`site` column](https://github.com/riasvdv/statamic-redirect/blob/09f32894f1accf8c7c0373f18298936a6d49f023/src/Blueprints/RedirectBlueprint.php#L29C69-L29C69).
* Fixes issue when using eloquent redirects with multisite. The multisite filter on the index-page expects a `site` column.