### PR TITLE
Fix handled dot indicator

### DIFF
--- a/resources/js/components/ErrorsListing.vue
+++ b/resources/js/components/ErrorsListing.vue
@@ -81,14 +81,16 @@
                 <span v-html="relativeDate(error.lastSeenAt)"></span>
               </template>
               <template slot="cell-handled" slot-scope="{ row: error }">
-                <div
-                  v-if="error.handled"
-                  class="bg-green block h-3 w-2 mr-auto rounded-full"
-                ></div>
-                <div
-                  v-else
-                  class="bg-red block h-3 w-2 mr-auto rounded-full"
-                ></div>
+                <div class="flex items-center">
+                  <div
+                    v-if="error.handled"
+                    class="little-dot mr-2 bg-green-600"
+                  ></div>
+                  <div
+                    v-else
+                    class="little-dot mr-2 bg-red-500"
+                  ></div>
+                </div>
               </template>
               <template slot="cell-handledDestination" slot-scope="{ row: error }">
                 <span style="word-break: break-all">{{ error.handledDestination }}</span>

--- a/resources/views/widgets/errors.blade.php
+++ b/resources/views/widgets/errors.blade.php
@@ -23,7 +23,7 @@
                     <tr class="sortable-row outline-none" tabindex="0">
                         <td class="">
                             <div class="flex items-center">
-                                <div class="little-dot mr-2 {{ $error->handled ? 'bg-green-600' : 'bg-gray-400' }}"></div>
+                                <div class="little-dot mr-2 {{ $error->handled ? 'bg-green-600' : 'bg-red-500' }}"></div>
                                 <a class="text-blue hover:text-blue-dark" href="{{ cp_route('redirect.errors.show', $error->id) }}" style="word-break: break-all">{{ $error->url }}</a>
                             </div>
                         </td>


### PR DESCRIPTION
The 'Handled" dot on the error index page is currently not visible.

![CleanShot 2024-01-07 at 16 52 48@2x](https://github.com/riasvdv/statamic-redirect/assets/22601927/3db39440-de03-40bb-ad09-12c8cda0ca59)

This PR solves this and makes the dot more consistent with the error widget.