### PR TITLE
change datatype in migration so unpadded datatypes are used in db

### DIFF
--- a/database/migrations/create_redirect_redirects_table.php.stub
+++ b/database/migrations/create_redirect_redirects_table.php.stub
@@ -12,8 +12,8 @@ class CreateRedirectRedirectsTable extends Migration
             $table->uuid('id')->unique()->index();
             $table->string('source')->index();
             $table->string('destination');
-            $table->char('match_type', 10);
-            $table->char('type', 10);
+            $table->string('match_type', 10);
+            $table->string('type', 10);
             $table->string('site')->index();
             $table->integer('order')->nullable();
             $table->boolean('enabled');


### PR DESCRIPTION
When using `char` in the migration of the `redirects` table, the resulting schema in postgres is using `bpchar(10)` as datatype, which gets padded with spaces. Those spaces are not removed by default, which means the redirects can not be resolved correctly from the database (e.g. `'regex     ' === 'regex'` in `Redirect::findByUrl`).

The resulting datatype in mysql (`char(10)`) gets also padded, but by default the trailing spaces are removed when the value is retrieved from the database. Therefore the problem described above do not arise when using mysql.

However, when using `string` in the migration, the redirects work with both database management systems.

See also:
- https://www.postgresql.org/docs/current/datatype-character.html 
- https://dev.mysql.com/doc/refman/8.0/en/char.html