### PR TITLE
Redirect description & default redirect type

### DIFF
--- a/config/redirect.php
+++ b/config/redirect.php
@@ -2,12 +2,12 @@
 
 return [
     /**
-     * Whether Redirect should be enabled
+     * Whether Redirect should be enabled.
      */
     'enable' => env('REDIRECT_ENABLED', true),
 
     /**
-     * Whether Redirect should preserve query strings
+     * Whether Redirect should preserve query strings.
      */
     'preserve_query_strings' => env('REDIRECT_PRESERVE_QUERY_STRINGS', false),
 
@@ -24,12 +24,12 @@ return [
     'delete_conflicting_redirects' => env('REDIRECT_DELETE_CONFLICTS', true),
 
     /**
-     * Controls whether Redirect logs 404 errors
+     * Controls whether Redirect logs 404 errors.
      */
     'log_errors' => env('REDIRECT_LOG_ERRORS', true),
 
     /**
-     * Controls whether Redirect logs individual hits
+     * Controls whether Redirect logs individual hits.
      */
     'log_hits' => env('REDIRECT_LOG_HITS', true),
 
@@ -49,37 +49,43 @@ return [
      */
     'clean_older_than' => '1 month',
 
-    /*
+    /**
      * The maximum number of unique errors to keep.
      * This does not include individual hits.
      */
     'keep_unique_errors' => 1000,
 
-    /*
-     * The database connection used to store errors. By default
+    /**
+     * The database connection used to store errors. By default,
      * this is the included 'redirect-sqlite'. Use
      * 'default' to use the Laravel default.
      */
     'error_connection' => env('REDIRECT_ERROR_CONNECTION', 'redirect-sqlite'),
 
-    /*
+    /**
      * The database connection used to store redirects. By
-     * default this is the included 'stache' connection.
+     * default, this is the included 'stache' connection.
      * Use 'default' to use the Laravel default.
      */
     'redirect_connection' => env('REDIRECT_REDIRECT_CONNECTION', 'stache'),
 
-    /*
+    /**
      * Customize where on filesystem the redirects are being stored in stache.
      * Useful when using a non-conventional setup where data should
-     * not be inside the usual content/redirects folder
+     * not be inside the usual content/redirects folder.
      */
     'redirect_store' => base_path('content/redirects'),
 
-    /*
-     * Customise the redirect repository you want to use for data
+    /**
+     * Customize the redirect repository you want to use for data
      * storage. Provide null to automaticly use a repository
      * based on the 'redirect_connection'.
      */
     'redirect_repository' => null,
+
+    /**
+     * Set the default redirect type for new redirects.
+     * Can be one of: 301, 302, 410.
+     */
+    'default_redirect_type' => 302,
 ];

--- a/database/migrations/add_description_to_redirect_redirects_table.php.stub
+++ b/database/migrations/add_description_to_redirect_redirects_table.php.stub
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDescriptionToRedirectRedirectsTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('redirects', function (Blueprint $table): void {
+            $table->text('description')->nullable()->after('enabled');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('redirects', function (Blueprint $table): void {
+            $table->dropColumn('description');
+        });
+    }
+}

--- a/src/Blueprints/RedirectBlueprint.php
+++ b/src/Blueprints/RedirectBlueprint.php
@@ -72,11 +72,11 @@ class RedirectBlueprint extends Blueprint
                                 'listable' => true,
                                 'validate' => 'required',
                                 'options' => [
-                                    '302' => 'Temporary (302)',
-                                    '301' => 'Permanent (301)',
-                                    '410' => 'Gone (410)',
+                                    302 => 'Temporary (302)',
+                                    301 => 'Permanent (301)',
+                                    410 => 'Gone (410)',
                                 ],
-                                'default' => '302',
+                                'default' => (int) config('statamic.redirect.default_redirect_type', 301),
                             ],
                         ],
                         [

--- a/src/Blueprints/RedirectBlueprint.php
+++ b/src/Blueprints/RedirectBlueprint.php
@@ -79,6 +79,16 @@ class RedirectBlueprint extends Blueprint
                                 'default' => '302',
                             ],
                         ],
+                        [
+                            'handle' => 'description',
+                            'field' => [
+                                'type' => 'textarea',
+                                'display' => 'Description',
+                                'instructions' => 'Extra information about this redirect. This is for internal use only.',
+                                'listable' => true,
+                                'validate' => 'nullable|string',
+                            ],
+                        ],
                     ],
                 ],
                 'sidebar' => [

--- a/src/Controllers/RedirectController.php
+++ b/src/Controllers/RedirectController.php
@@ -96,7 +96,8 @@ class RedirectController
             ->destination($request->get('destination'))
             ->enabled($request->get('enabled'))
             ->type($request->get('type'))
-            ->matchType($request->get('match_type'));
+            ->matchType($request->get('match_type'))
+            ->description($request->get('description'));
 
         $redirect->save();
 
@@ -132,7 +133,8 @@ class RedirectController
             ->destination($request->get('destination'))
             ->enabled($request->get('enabled'))
             ->type($request->get('type'))
-            ->matchType($request->get('match_type'));
+            ->matchType($request->get('match_type'))
+            ->description($request->get('description'));
 
         $redirect->save();
 

--- a/src/Data/Redirect.php
+++ b/src/Data/Redirect.php
@@ -44,6 +44,9 @@ class Redirect implements Localization, RedirectContract
     /** @var int */
     protected $order;
 
+    /** @var string|null */
+    protected $description;
+
     public function id($id = null)
     {
         return $this->fluentlyGetOrSet('id')->args(func_get_args());
@@ -115,6 +118,11 @@ class Redirect implements Localization, RedirectContract
         ]);
     }
 
+    public function description($matchType = null)
+    {
+        return $this->fluentlyGetOrSet('description')->args(func_get_args());
+    }
+
     public function save()
     {
         return RedirectFacade::save($this);
@@ -134,6 +142,7 @@ class Redirect implements Localization, RedirectContract
             'destination' => $this->destination(),
             'type' => $this->type(),
             'match_type' => $this->matchType(),
+            'description' => $this->description(),
             'order' => $this->order(),
         ];
     }

--- a/src/Data/Redirect.php
+++ b/src/Data/Redirect.php
@@ -32,8 +32,8 @@ class Redirect implements Localization, RedirectContract
     /** @var string */
     protected $destination;
 
-    /** @var string */
-    protected $type = '301';
+    /** @var int */
+    protected $type = 301;
 
     /** @var string */
     protected $locale;

--- a/src/Eloquent/Redirects/RedirectRepository.php
+++ b/src/Eloquent/Redirects/RedirectRepository.php
@@ -109,7 +109,8 @@ class RedirectRepository implements RepositoryContract
             ->matchType($model->match_type)
             ->enabled($model->enabled)
             ->order($model->order)
-            ->locale($model->site);
+            ->locale($model->site)
+            ->description($model->description);
     }
 
     private function toModel(Redirect $redirect)
@@ -122,6 +123,7 @@ class RedirectRepository implements RepositoryContract
             'enabled' => $redirect->enabled(),
             'order' => $redirect->order(),
             'site' => $redirect->locale(),
+            'description' => $redirect->description(),
         ];
 
         $model = RedirectModel::firstOrNew(['id' => $redirect->id()], $properties);

--- a/src/Http/Resources/ListedRedirect.php
+++ b/src/Http/Resources/ListedRedirect.php
@@ -30,6 +30,7 @@ class ListedRedirect extends JsonResource
             'match_type' => $redirect->matchType(),
             'site' => $redirect->site(),
             'order' => $redirect->order(),
+            'description' => $redirect->description(),
             'delete_url' => cp_route('redirect.redirects.delete', $redirect->id()),
         ];
     }

--- a/src/RedirectServiceProvider.php
+++ b/src/RedirectServiceProvider.php
@@ -120,6 +120,7 @@ class RedirectServiceProvider extends AddonServiceProvider
 
         $this->publishes([
             __DIR__ . '/../database/migrations/create_redirect_redirects_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_redirect_redirects_table.php'),
+            __DIR__ . '/../database/migrations/add_description_to_redirect_redirects_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_add_description_to_redirect_redirects_table.php'),
         ], 'statamic-redirect-redirect-migrations');
     }
 


### PR DESCRIPTION
Hi @riasvdv!

First of all, thank you for this great package, it's exactly what we needed!

Well, *almost* exactly 😉 While implementing we realized we're missing the following two functionalities:
1. Adding a description to a redirect, which could be a name, a date, etc. Our client needed something like that, purely for internal use, and we figured that it may also benefit others!
   * I have also added a new migration for this, hopefully that aligns with how you would see it.
2. Setting the default redirect type. Currently it's always `302`, but our client needs it to be `301`. This is also something we figured might be interesting for others.
   * I have changed the type from `string` to `int`, as otherwise the dropdown wouldn't get filled correctly!

If you have any questions, or if you would like something changed, don't hesitate to let me know!