### PR TITLE
Multi-site improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.php_cs.cache
 /.php-cs-fixer.cache
 /.phpunit.result.cache
+/.phpunit.cache
 /composer.lock
 /tests/_reports
 /vendor

--- a/src/Blueprints/RedirectBlueprint.php
+++ b/src/Blueprints/RedirectBlueprint.php
@@ -2,12 +2,9 @@
 
 namespace Rias\StatamicRedirect\Blueprints;
 
-use Closure;
-use Illuminate\Support\Facades\Session;
 use Rias\StatamicRedirect\Enums\MatchTypeEnum;
-use Rias\StatamicRedirect\Facades\Redirect;
+use Rias\StatamicRedirect\Rules\SourceIsNotRedirected;
 use Statamic\Facades\Blueprint;
-use Statamic\Facades\Site;
 
 class RedirectBlueprint extends Blueprint
 {
@@ -24,19 +21,7 @@ class RedirectBlueprint extends Blueprint
                                 'display' => 'Source',
                                 'instructions' => 'Enter the URL pattern that Redirect should match. This matches against the path only e.g.: Exact Match: `/recipes/`, or RegEx Match: `.*RecipeID=(.*)`',
                                 'listable' => true,
-                                'validate' => ['required', 'string', function (string $attribute, $value, Closure $fail) {
-                                    $selectedSite = Session::get('statamic.cp.selected-site', Site::current()->handle());
-
-                                    $existing = Redirect::query()
-                                        ->where('source', $value)
-                                        ->when(request()->route('id'), fn ($query) => $query->where('id', '!=', request()->route('id')))
-                                        ->where('site', $selectedSite)
-                                        ->first();
-
-                                    if ($existing) {
-                                        $fail(__("This source already has a redirect associated with it."));
-                                    }
-                                }],
+                                'validate' => ['required', 'string', new SourceIsNotRedirected],
                             ],
                         ],
                         [

--- a/src/Blueprints/RedirectBlueprint.php
+++ b/src/Blueprints/RedirectBlueprint.php
@@ -103,6 +103,17 @@ class RedirectBlueprint extends Blueprint
                                 'validate' => 'required|boolean',
                             ],
                         ],
+                        [
+                            'handle' => 'site',
+                            'field' => [
+                                'type' => 'sites',
+                                'display' => 'Site',
+                                'max_items' => 1,
+                                'mode' => 'select',
+                                'listable' => true,
+                                'validate' => 'required',
+                            ],
+                        ],
                     ],
                 ],
             ],

--- a/src/Controllers/ImportRedirectsController.php
+++ b/src/Controllers/ImportRedirectsController.php
@@ -64,7 +64,7 @@ class ImportRedirectsController
                 ->matchType($data['match_type']);
 
             if (isset($data['site'])) {
-                $redirect->locale($data['site']);
+                $redirect->site($data['site']);
             }
 
             $redirect->save();

--- a/src/Controllers/RedirectController.php
+++ b/src/Controllers/RedirectController.php
@@ -8,18 +8,15 @@ use Rias\StatamicRedirect\Blueprints\RedirectBlueprint;
 use Rias\StatamicRedirect\Facades\Redirect;
 use Rias\StatamicRedirect\Http\Resources\ListedRedirect;
 use Statamic\Facades\Scope;
-use Statamic\Facades\Site;
 use Statamic\Facades\User;
 
 class RedirectController
 {
-    public function index(Request $request)
+    public function index()
     {
         $user = User::fromUser(auth()->user());
 
         abort_unless($user->isSuper() || $user->hasPermission('view redirects'), 401);
-
-        $site = $request->site ? Site::get($request->site) : Site::selected();
 
         $blueprint = new RedirectBlueprint();
         $columns = $blueprint()
@@ -29,15 +26,8 @@ class RedirectController
             ->values();
 
         return view('redirect::redirects.index', [
-            'site' => $site->handle(),
             'filters' => Scope::filters('redirects'),
             'columns' => $columns,
-            'sites' => Site::all()->map(function (\Statamic\Sites\Site $site) {
-                return [
-                    'handle' => $site->handle(),
-                    'name' => $site->name(),
-                ];
-            })->values()->all(),
         ]);
     }
 
@@ -84,14 +74,16 @@ class RedirectController
 
         abort_unless($user->isSuper() || $user->hasPermission('create redirects'), 401);
 
+        if (empty($request->get('site'))) {
+            abort(402, 'Site is required');
+        }
+
         $blueprint = new RedirectBlueprint();
         $fields = $blueprint()->fields()->addValues($request->all());
         $fields->validate();
 
-        $selectedSite = $request->session()->get('statamic.cp.selected-site', Site::current()->handle());
-
         $redirect = Redirect::make()
-            ->locale($selectedSite)
+            ->site($request->get('site')[0])
             ->source($request->get('source'))
             ->destination($request->get('destination'))
             ->enabled($request->get('enabled'))
@@ -121,14 +113,12 @@ class RedirectController
 
         $redirect = Redirect::find($id);
 
-        $selectedSite = $request->session()->get('statamic.cp.selected-site', Site::current()->handle());
-
         if (! $redirect) {
             abort('404');
         }
 
         $redirect
-            ->locale($selectedSite)
+            ->site($request->get('site')[0])
             ->source($request->get('source'))
             ->destination($request->get('destination'))
             ->enabled($request->get('enabled'))

--- a/src/Data/Redirect.php
+++ b/src/Data/Redirect.php
@@ -6,14 +6,13 @@ use Rias\StatamicRedirect\Contracts\Redirect as RedirectContract;
 use Rias\StatamicRedirect\Data\Concerns\TracksQueriedRelations;
 use Rias\StatamicRedirect\Enums\MatchTypeEnum;
 use Rias\StatamicRedirect\Facades\Redirect as RedirectFacade;
-use Statamic\Contracts\Data\Localization;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Data\TracksQueriedColumns;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class Redirect implements Localization, RedirectContract
+class Redirect implements RedirectContract
 {
     use FluentlyGetsAndSets;
     use ExistsAsFile;
@@ -36,7 +35,7 @@ class Redirect implements Localization, RedirectContract
     protected $type = 301;
 
     /** @var string */
-    protected $locale;
+    protected $site;
 
     /** @var string */
     protected $matchType = MatchTypeEnum::EXACT;
@@ -82,37 +81,35 @@ class Redirect implements Localization, RedirectContract
         return $this->fluentlyGetOrSet('order')->args(func_get_args());
     }
 
-    public function locale($locale = null)
-    {
-        return $this
-            ->fluentlyGetOrSet('locale')
-            ->setter(function ($locale) {
-                return $locale instanceof \Statamic\Sites\Site ? $locale->handle() : $locale;
-            })
-            ->getter(function ($locale) {
-                return $locale ?? Site::default()->handle();
-            })
-            ->args(func_get_args());
-    }
-
-    public function setLocaleFromFilePath($path)
+    public function setSiteFromFilePath($path)
     {
         $explodedPath = explode('/', $path);
-        $locale = $explodedPath[count($explodedPath) - 2]; // locale is 2nd last path segment
+        $site = $explodedPath[count($explodedPath) - 2]; // site is 2nd last path segment
 
-        return $this->locale($locale);
+        return $this->site($site);
     }
 
-    public function site()
+    public function site($site = null)
     {
-        return Site::get($this->locale());
+        return $this
+            ->fluentlyGetOrSet('site')
+            ->setter(function ($site) {
+                $siteHandle = $site instanceof \Statamic\Sites\Site ? $site->handle() : $site;
+
+                $this->site = $siteHandle;
+                return $siteHandle;
+            })
+            ->getter(function ($site) {
+                return $site ?? Site::default()->handle();
+            })
+            ->args(func_get_args());
     }
 
     public function path()
     {
         return vsprintf('%s/%s/%s%s.yaml', [
             rtrim(Stache::store('redirects')->directory(), '/'),
-            $this->locale(),
+            $this->site(),
             ! is_null($this->order()) ? $this->order() . '_' : '',
             $this->id(),
         ]);
@@ -141,6 +138,7 @@ class Redirect implements Localization, RedirectContract
             'source' => $this->source(),
             'destination' => $this->destination(),
             'type' => $this->type(),
+            'site' => $this->site(),
             'match_type' => $this->matchType(),
             'description' => $this->description(),
             'order' => $this->order(),

--- a/src/Eloquent/Redirects/RedirectRepository.php
+++ b/src/Eloquent/Redirects/RedirectRepository.php
@@ -109,7 +109,7 @@ class RedirectRepository implements RepositoryContract
             ->matchType($model->match_type)
             ->enabled($model->enabled)
             ->order($model->order)
-            ->locale($model->site)
+            ->site($model->site)
             ->description($model->description);
     }
 
@@ -122,7 +122,7 @@ class RedirectRepository implements RepositoryContract
             'type' => $redirect->type(),
             'enabled' => $redirect->enabled(),
             'order' => $redirect->order(),
-            'site' => $redirect->locale(),
+            'site' => $redirect->site(),
             'description' => $redirect->description(),
         ];
 

--- a/src/Http/Filters/RedirectSite.php
+++ b/src/Http/Filters/RedirectSite.php
@@ -2,10 +2,32 @@
 
 namespace Rias\StatamicRedirect\Http\Filters;
 
-class RedirectSite extends \Statamic\Query\Scopes\Filters\Site
+use Rias\StatamicRedirect\Facades\Redirect;
+use Statamic\Query\Scopes\Filters\Site;
+
+class RedirectSite extends Site
 {
-    public function visibleTo($key)
+    public function visibleTo($key): bool
     {
         return $key === 'redirects' && \Statamic\Facades\Site::hasMultiple();
+    }
+
+    protected function availableSites()
+    {
+        if (! \Statamic\Facades\Site::hasMultiple()) {
+            return collect();
+        }
+
+        $configuredSites = collect();
+        $redirects = Redirect::all();
+        foreach ($redirects as $redirect) {
+            if (! $configuredSites->contains($redirect->site())) {
+                $configuredSites->add($redirect->site());
+            }
+        }
+
+        return \Statamic\Facades\Site::authorized()->filter(function ($site) use ($configuredSites) {
+            return $configuredSites->contains($site->handle());
+        });
     }
 }

--- a/src/Listeners/CreateRedirect.php
+++ b/src/Listeners/CreateRedirect.php
@@ -22,7 +22,7 @@ class CreateRedirect
          * If we have a redirect with a source of the
          * NEW uri we should remove this redirect.
          */
-        if (config('statamic.redirect.delete_conflicting_redirects', true) && $entry->uri() && $entry->published() && $existingRedirect = Redirect::findByUrl($entry->locale(), $entry->uri())) {
+        if (config('statamic.redirect.delete_conflicting_redirects', true) && $entry->uri() && $entry->published() && $existingRedirect = Redirect::findByUrl($entry->site(), $entry->uri())) {
             $existingRedirect->delete();
         }
 
@@ -39,7 +39,7 @@ class CreateRedirect
         }
 
         Redirect::make()
-            ->locale($entry->locale())
+            ->site($entry->site())
             ->source($oldUri)
             ->destination($entry->uri())
             ->matchType(MatchTypeEnum::EXACT)

--- a/src/Rules/SourceIsNotRedirected.php
+++ b/src/Rules/SourceIsNotRedirected.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rias\StatamicRedirect\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Rias\StatamicRedirect\Facades\Redirect;
+
+class SourceIsNotRedirected implements DataAwareRule, ValidationRule
+{
+    protected array $data = [];
+
+    public function validate(string $attribute, $value, Closure $fail): void
+    {
+        $existing = Redirect::query()
+            ->where('source', $value)
+            ->when(request()->route('id'), fn ($query) => $query->where('id', '!=', request()->route('id')))
+            ->where('site', $this->data['site'][0])
+            ->first();
+
+        if ($existing) {
+            $fail(__("This source already has a redirect associated with it."));
+        }
+    }
+
+    public function setData(array $data): self
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+}

--- a/src/Stache/Redirects/RedirectRepository.php
+++ b/src/Stache/Redirects/RedirectRepository.php
@@ -39,7 +39,7 @@ class RedirectRepository implements RepositoryContract
         // Try and find a static redirect first as that's a quicker query
         $staticRedirect = $this->query()
             ->where('enabled', true)
-            ->where('locale', $siteHandle)
+            ->where('site', $siteHandle)
             ->where(function (RedirectQueryBuilder $query) use ($url) {
                 $query
                     ->orWhere('source', $url)

--- a/src/Stache/Redirects/RedirectStore.php
+++ b/src/Stache/Redirects/RedirectStore.php
@@ -36,7 +36,7 @@ class RedirectStore extends BasicStore
             ->matchType(Arr::pull($data, 'match_type'))
             ->enabled(Arr::pull($data, 'enabled'))
             ->order(Arr::pull($data, 'order'))
-            ->setLocaleFromFilePath($path)
+            ->setSiteFromFilePath($path)
             ->initialPath($path);
 
         if (isset($idGenerated)) {

--- a/tests/Feature/Middleware/HandleNotFoundTest.php
+++ b/tests/Feature/Middleware/HandleNotFoundTest.php
@@ -456,7 +456,7 @@ class HandleNotFoundTest extends TestCase
     public function it_will_not_find_redirects_from_different_sites()
     {
         Redirect::make()
-            ->locale('some-different-site')
+            ->site('some-different-site')
             ->source('/abc')
             ->destination('/def')
             ->save();


### PR DESCRIPTION
Closes #186
Closes #200
Covers #118, but does not close it:
I added a site column to the index, a site selector to the blueprint and made the site filter on the index work as expected.
The UI can still be further improved by allowing easily duplicating a redirect from one site to another (like with entries), but I can't figure out how to get this working, so maybe someone with more experience in this can look into implementing that.
Another option would be to make the site selection multi-select, but this does not currently align with the DB so then it would be necessary to look into migrating this data properly.

# Features
- Used `site` instead of `locale`
  _Statamic has since switched over, best for the plugin to follow this new implementation_
- Created separate `SourceIsNotRedirected` rule object
  _This allows validating the source is unique within the site it is being created for_
- Overwritten `availableSites` method in `RedirectSite` filter
  _The default implementation does not work for an index outside of the entry collections_
- Added support for sites with path segments
  _Noticed that this was something also raised in a issue, figured I might as well include this in the changes_
- Added `.phpunit.cache` directory to gitignore
  _This directory is created when running the tests locally, but should not be commited_