### PR TITLE
Support URLs up to 2048 characters

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
+        php: [8.2, 8.3, 8.4]
         statamic: [5.*]
         include:
           - statamic: 5.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,15 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3, 8.4]
-        statamic: [4.*, 5.*]
-        exclude:
-          - statamic: 4.*
-            php: 8.4
+        statamic: [5.*]
         include:
-          - statamic: 4.*
-            testbench: ^7.0
           - statamic: 5.*
-            testbench: ^8.0
+            testbench: ^9.0
 
     name: PHP ${{ matrix.php }} - Statamic ${{ matrix.statamic }}
     

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /vendor
 mix-manifest.json
 node_modules
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
         "ext-json": "*",
         "php": "^7.4|^8.0",
         "spatie/simple-excel": "^1.0|^2.0|^3.0",
-        "statamic/cms": "^4.10|^5.0"
+        "statamic/cms": "^4.10|^5.0",
+        "doctrine/dbal": "^4.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.10",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "php": "^7.4|^8.0",
         "spatie/simple-excel": "^1.0|^2.0|^3.0",
         "statamic/cms": "^4.10|^5.0",
-        "doctrine/dbal": "^3.9|^4.2"
+        "doctrine/dbal": "^2.13.9|^4.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.10",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "php": "^7.4|^8.0",
         "spatie/simple-excel": "^1.0|^2.0|^3.0",
         "statamic/cms": "^4.10|^5.0",
-        "doctrine/dbal": "^2.13.9|^4.2"
+        "doctrine/dbal": "^4.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.10",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "php": "^7.4|^8.0",
         "spatie/simple-excel": "^1.0|^2.0|^3.0",
         "statamic/cms": "^4.10|^5.0",
-        "doctrine/dbal": "^4.2"
+        "doctrine/dbal": "^3.9|^4.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.10",

--- a/database/migrations/increase_redirect_error_table_url_length.php.stub
+++ b/database/migrations/increase_redirect_error_table_url_length.php.stub
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class IncreaseRedirectErrorTableUrlLength extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('errors', function (Blueprint $table): void {
+            $table->dropIndex('errors_url_index');
+        });
+
+        Schema::table('errors', function (Blueprint $table): void {
+            $table->string('url', 2048)->change();
+            $table->string('url_md5')->index()->after('url');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('errors', function (Blueprint $table): void {
+            $table->dropColumn('url_md5');
+            $table->string('url')->index()->change();
+        });
+    }
+}

--- a/database/migrations/increase_redirect_error_table_url_length.php.stub
+++ b/database/migrations/increase_redirect_error_table_url_length.php.stub
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Rias\StatamicRedirect\Data\Error;
 
 class IncreaseRedirectErrorTableUrlLength extends Migration
 {
@@ -15,6 +16,10 @@ class IncreaseRedirectErrorTableUrlLength extends Migration
         Schema::table('errors', function (Blueprint $table): void {
             $table->string('url', 2048)->change();
             $table->string('url_md5')->index()->after('url');
+        });
+
+        Error::each(function (Error $error) {
+            $error->update(['url_md5' => md5($error->url)]);
         });
     }
 

--- a/database/migrations/increase_redirect_redirects_table_url_length.php.stub
+++ b/database/migrations/increase_redirect_redirects_table_url_length.php.stub
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class IncreaseRedirectRedirectsTableUrlLength extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('redirects', function (Blueprint $table): void {
+            $table->dropIndex('redirects_source_index');
+        });
+
+        Schema::table('redirects', function (Blueprint $table): void {
+            $table->string('source', 2048)->change();
+            $table->string('source_md5')->index()->after('source');
+            $table->string('destination', 2048)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('redirects', function (Blueprint $table): void {
+            $table->dropColumn('source_md5');
+            $table->string('source')->index()->change();
+            $table->string('destination')->change();
+        });
+    }
+}

--- a/database/migrations/increase_redirect_redirects_table_url_length.php.stub
+++ b/database/migrations/increase_redirect_redirects_table_url_length.php.stub
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Rias\StatamicRedirect\Eloquent\Redirects\RedirectModel;
 
 class IncreaseRedirectRedirectsTableUrlLength extends Migration
 {
@@ -16,6 +17,10 @@ class IncreaseRedirectRedirectsTableUrlLength extends Migration
             $table->string('source', 2048)->change();
             $table->string('source_md5')->index()->after('source');
             $table->string('destination', 2048)->change();
+        });
+
+        RedirectModel::each(function (RedirectModel $redirect) {
+            $redirect->update(['source_md5' => md5($redirect->source)]);
         });
     }
 

--- a/src/Data/Error.php
+++ b/src/Data/Error.php
@@ -37,6 +37,9 @@ class Error extends Model
 
     protected static function booted()
     {
+        self::saving(function ($model) {
+            $model->url_md5 = md5($model->url);
+        });
         self::deleting(function ($error) {
             $error->hits()->delete();
         });
@@ -70,6 +73,6 @@ class Error extends Model
 
     public static function findByUrl(string $url): ?self
     {
-        return self::where('url', $url)->first();
+        return self::where('url_md5', md5($url))->where('url', $url)->first();
     }
 }

--- a/src/Data/Redirect.php
+++ b/src/Data/Redirect.php
@@ -30,6 +30,9 @@ class Redirect implements Localization, RedirectContract
     protected $source;
 
     /** @var string */
+    protected $source_md5;
+
+    /** @var string */
     protected $destination;
 
     /** @var int */
@@ -60,6 +63,11 @@ class Redirect implements Localization, RedirectContract
     public function source($source = null)
     {
         return $this->fluentlyGetOrSet('source')->args(func_get_args());
+    }
+
+    public function source_md5($source_md5 = null)
+    {
+        return $this->fluentlyGetOrSet('source_md5')->args(func_get_args());
     }
 
     public function destination($destination = null)

--- a/src/RedirectServiceProvider.php
+++ b/src/RedirectServiceProvider.php
@@ -22,6 +22,8 @@ use Rias\StatamicRedirect\Stache\Redirects\RedirectStore;
 use Rias\StatamicRedirect\UpdateScripts\AddDescriptionColumnToRedirectsTable;
 use Rias\StatamicRedirect\UpdateScripts\AddHitsCount;
 use Rias\StatamicRedirect\UpdateScripts\ClearErrors;
+use Rias\StatamicRedirect\UpdateScripts\IncreaseUrlSizeOnErrors;
+use Rias\StatamicRedirect\UpdateScripts\IncreaseUrlSizeOnRedirects;
 use Rias\StatamicRedirect\UpdateScripts\MoveRedirectsToDefaultSite;
 use Rias\StatamicRedirect\UpdateScripts\RenameLocaleToSiteOnRedirectsTable;
 use Rias\StatamicRedirect\Widgets\ErrorsLastDayWidget;
@@ -45,6 +47,8 @@ class RedirectServiceProvider extends AddonServiceProvider
         MoveRedirectsToDefaultSite::class,
         RenameLocaleToSiteOnRedirectsTable::class,
         AddDescriptionColumnToRedirectsTable::class,
+        IncreaseUrlSizeOnRedirects::class,
+        IncreaseUrlSizeOnErrors::class,
     ];
 
     protected $scripts = [
@@ -124,7 +128,7 @@ class RedirectServiceProvider extends AddonServiceProvider
         $this->publishes([
             __DIR__ . '/../database/migrations/create_redirect_redirects_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_redirect_redirects_table.php'),
             __DIR__ . '/../database/migrations/add_description_to_redirect_redirects_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time() + 1) . '_add_description_to_redirect_redirects_table.php'),
-            __DIR__ . '/../database/migrations/increase_redirect_redirects_table_url_length.php.stub' => database_path('migrations/' . date('Y_m_d_His', time() + 1) . '_increase_redirect_redirects_table_url_length.php'),
+            __DIR__ . '/../database/migrations/increase_redirect_redirects_table_url_length.php.stub' => database_path('migrations/' . date('Y_m_d_His', time() + 2) . '_increase_redirect_redirects_table_url_length.php'),
         ], 'statamic-redirect-redirect-migrations');
     }
 

--- a/src/RedirectServiceProvider.php
+++ b/src/RedirectServiceProvider.php
@@ -48,11 +48,11 @@ class RedirectServiceProvider extends AddonServiceProvider
     ];
 
     protected $scripts = [
-        __DIR__.'/../resources/dist/js/cp.js',
+        __DIR__ . '/../resources/dist/js/cp.js',
     ];
 
     protected $routes = [
-        'cp' => __DIR__.'/../routes/cp.php',
+        'cp' => __DIR__ . '/../routes/cp.php',
     ];
 
     protected $listen = [
@@ -112,19 +112,19 @@ class RedirectServiceProvider extends AddonServiceProvider
                 ->bootPermissions();
         });
 
-        if (! $this->app->runningInConsole()) {
+        if (!$this->app->runningInConsole()) {
             return;
         }
 
         $this->publishes([
             __DIR__ . '/../database/migrations/create_redirect_error_tables.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_redirect_error_tables.php'),
-            __DIR__ . '/../database/migrations/increase_redirect_error_table_url_length.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_increase_redirect_error_table_url_length.php'),
+            __DIR__ . '/../database/migrations/increase_redirect_error_table_url_length.php.stub' => database_path('migrations/' . date('Y_m_d_His', time() + 1) . '_increase_redirect_error_table_url_length.php'),
         ], 'statamic-redirect-error-migrations');
 
         $this->publishes([
             __DIR__ . '/../database/migrations/create_redirect_redirects_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_redirect_redirects_table.php'),
-            __DIR__ . '/../database/migrations/add_description_to_redirect_redirects_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_add_description_to_redirect_redirects_table.php'),
-            __DIR__ . '/../database/migrations/increase_redirect_redirects_table_url_length.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_increase_redirect_redirects_table_url_length.php'),
+            __DIR__ . '/../database/migrations/add_description_to_redirect_redirects_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time() + 1) . '_add_description_to_redirect_redirects_table.php'),
+            __DIR__ . '/../database/migrations/increase_redirect_redirects_table_url_length.php.stub' => database_path('migrations/' . date('Y_m_d_His', time() + 1) . '_increase_redirect_redirects_table_url_length.php'),
         ], 'statamic-redirect-redirect-migrations');
     }
 
@@ -143,7 +143,7 @@ class RedirectServiceProvider extends AddonServiceProvider
 
     protected function bootAddonViews()
     {
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'redirect');
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'redirect');
 
         return $this;
     }
@@ -162,8 +162,8 @@ class RedirectServiceProvider extends AddonServiceProvider
             $nav->tools('Redirect')
                 ->route(
                     config('statamic.redirect.log_errors')
-                    ? 'redirect.index'
-                    : 'redirect.redirects.index'
+                        ? 'redirect.index'
+                        : 'redirect.redirects.index'
                 )
                 ->icon('git')
                 ->active('redirect')
@@ -185,7 +185,7 @@ class RedirectServiceProvider extends AddonServiceProvider
 
     protected function bootDatabase()
     {
-        if (! config('statamic.redirect.log_errors')) {
+        if (!config('statamic.redirect.log_errors')) {
             return $this;
         }
 
@@ -209,17 +209,17 @@ class RedirectServiceProvider extends AddonServiceProvider
     {
         $oldSqlitePath = storage_path('redirect/errors.sqlite');
 
-        if (! file_exists($sqlitePath) && file_exists($oldSqlitePath)) {
+        if (!file_exists($sqlitePath) && file_exists($oldSqlitePath)) {
             File::move($oldSqlitePath, $sqlitePath);
 
             return;
         }
 
-        if (! file_exists($sqlitePath)) {
+        if (!file_exists($sqlitePath)) {
             File::put($sqlitePath, '');
 
             $gitIgnorePath = storage_path('redirect/.gitignore');
-            if (! file_exists($gitIgnorePath)) {
+            if (!file_exists($gitIgnorePath)) {
                 File::put($gitIgnorePath, "*\n!.gitignore");
             }
         }
@@ -229,7 +229,7 @@ class RedirectServiceProvider extends AddonServiceProvider
     {
         if (
             config('statamic.redirect.error_connection', 'redirect-sqlite') !== 'redirect-sqlite' &&
-            ! $this->generalConnectionIsBuiltinSqlite()
+            !$this->generalConnectionIsBuiltinSqlite()
         ) {
             return;
         }
@@ -251,7 +251,7 @@ class RedirectServiceProvider extends AddonServiceProvider
     {
         if (
             config('statamic.redirect.redirect_connection', 'stache') !== 'redirect-sqlite' &&
-            ! $this->generalConnectionIsBuiltinSqlite()
+            !$this->generalConnectionIsBuiltinSqlite()
         ) {
             return;
         }
@@ -288,10 +288,10 @@ class RedirectServiceProvider extends AddonServiceProvider
 
     protected function registerAddonConfig()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/redirect.php', 'statamic.redirect');
+        $this->mergeConfigFrom(__DIR__ . '/../config/redirect.php', 'statamic.redirect');
 
         $this->publishes([
-            __DIR__.'/../config/redirect.php' => config_path('statamic/redirect.php'),
+            __DIR__ . '/../config/redirect.php' => config_path('statamic/redirect.php'),
         ], 'statamic-redirect-config');
 
         return $this;

--- a/src/RedirectServiceProvider.php
+++ b/src/RedirectServiceProvider.php
@@ -118,11 +118,13 @@ class RedirectServiceProvider extends AddonServiceProvider
 
         $this->publishes([
             __DIR__ . '/../database/migrations/create_redirect_error_tables.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_redirect_error_tables.php'),
+            __DIR__ . '/../database/migrations/increase_redirect_error_table_url_length.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_increase_redirect_error_table_url_length.php'),
         ], 'statamic-redirect-error-migrations');
 
         $this->publishes([
             __DIR__ . '/../database/migrations/create_redirect_redirects_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_redirect_redirects_table.php'),
             __DIR__ . '/../database/migrations/add_description_to_redirect_redirects_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_add_description_to_redirect_redirects_table.php'),
+            __DIR__ . '/../database/migrations/increase_redirect_redirects_table_url_length.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_increase_redirect_redirects_table_url_length.php'),
         ], 'statamic-redirect-redirect-migrations');
     }
 
@@ -240,6 +242,8 @@ class RedirectServiceProvider extends AddonServiceProvider
         DB::setDefaultConnection('redirect-sqlite');
         require_once(__DIR__ . '/../database/migrations/create_redirect_error_tables.php.stub');
         (new \CreateRedirectErrorTables())->up();
+        require_once(__DIR__ . '/../database/migrations/increase_redirect_error_table_url_length.php.stub');
+        (new \IncreaseRedirectErrorTableUrlLength())->up();
         DB::setDefaultConnection($defaultConnection);
     }
 
@@ -263,6 +267,8 @@ class RedirectServiceProvider extends AddonServiceProvider
         (new \CreateRedirectRedirectsTable())->up();
         require_once(__DIR__ . '/../database/migrations/add_description_to_redirect_redirects_table.php.stub');
         (new \AddDescriptionToRedirectRedirectsTable())->up();
+        require_once(__DIR__ . '/../database/migrations/increase_redirect_redirects_table_url_length.php.stub');
+        (new \IncreaseRedirectRedirectsTableUrlLength())->up();
 
         DB::setDefaultConnection($defaultConnection);
     }

--- a/src/UpdateScripts/AddDescriptionColumnToRedirectsTable.php
+++ b/src/UpdateScripts/AddDescriptionColumnToRedirectsTable.php
@@ -3,6 +3,7 @@
 namespace Rias\StatamicRedirect\UpdateScripts;
 
 use Illuminate\Database\QueryException;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schema;
 use Statamic\UpdateScripts\UpdateScript;
@@ -31,6 +32,18 @@ class AddDescriptionColumnToRedirectsTable extends UpdateScript
 
     public function update()
     {
+        $connection = config('statamic.redirect.redirect_connection');
+
+        if ($connection === 'redirect-sqlite') {
+            Schema::connection($connection)->table('redirects', function (Blueprint $table): void {
+                $table->text('description')->nullable()->after('enabled');
+            });
+
+            $this->console()->info('Added description field to the redirects table!');
+
+            return;
+        }
+
         Artisan::call('vendor:publish', [
             '--tag' => 'statamic-redirect-redirect-migrations',
         ]);

--- a/src/UpdateScripts/IncreaseUrlSizeOnErrors.php
+++ b/src/UpdateScripts/IncreaseUrlSizeOnErrors.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rias\StatamicRedirect\UpdateScripts;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schema;
+use Rias\StatamicRedirect\Data\Error;
+use Statamic\UpdateScripts\UpdateScript;
+
+class IncreaseUrlSizeOnErrors extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        $errorConnection = config('statamic.redirect.error_connection');
+
+        if ($errorConnection === 'default') {
+            $errorConnection = config('database.default');
+        }
+
+        try {
+            return ! Schema::connection($errorConnection)->hasColumn('errors', 'url_md5');
+        } catch (QueryException) {
+            // Query exception happens when database is not set up
+            return false;
+        }
+    }
+
+    public function update()
+    {
+        $errorConnection = config('statamic.redirect.error_connection');
+
+        if ($errorConnection === 'redirect-sqlite') {
+            if (Schema::connection($errorConnection)->hasIndex('errors', 'errors_url_index')) {
+                Schema::connection($errorConnection)->table('errors', function (Blueprint $table): void {
+                    $table->dropIndex('errors_url_index');
+                });
+            }
+
+            Schema::connection($errorConnection)->table('errors', function (Blueprint $table): void {
+                $table->string('url', 2048)->change();
+                $table->string('url_md5')->index()->nullable()->after('url');
+            });
+
+            Error::each(function (Error $error) {
+                $error->update(['url_md5' => md5($error->url)]);
+            });
+
+            $this->console()->info('Increased url column size in errors table.');
+
+            return;
+        }
+
+        Artisan::call('vendor:publish', [
+            '--tag' => 'statamic-redirect-error-migrations',
+        ]);
+
+        $this->console()->info('New migration for Redirects published, make sure to run it!');
+    }
+}

--- a/src/UpdateScripts/IncreaseUrlSizeOnRedirects.php
+++ b/src/UpdateScripts/IncreaseUrlSizeOnRedirects.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Rias\StatamicRedirect\UpdateScripts;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schema;
+use Rias\StatamicRedirect\Eloquent\Redirects\RedirectModel;
+use Statamic\UpdateScripts\UpdateScript;
+
+class IncreaseUrlSizeOnRedirects extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        $redirectConnection = config('statamic.redirect.redirect_connection');
+
+        if ($redirectConnection === 'stache') {
+            return false;
+        }
+
+        if ($redirectConnection === 'default') {
+            $redirectConnection = config('database.default');
+        }
+
+        try {
+            return ! Schema::connection($redirectConnection)->hasColumn('redirects', 'source_md5');
+        } catch (QueryException) {
+            // Query exception happens when database is not set up
+            return false;
+        }
+    }
+
+    public function update()
+    {
+        $redirectConnection = config('statamic.redirect.redirect_connection');
+
+        if ($redirectConnection === 'redirect-sqlite') {
+            if (Schema::connection($redirectConnection)->hasIndex('redirects', 'redirects_source_index')) {
+                Schema::connection($redirectConnection)->table('redirects', function (Blueprint $table): void {
+                    $table->dropIndex('redirects_source_index');
+                });
+            }
+
+            Schema::connection($redirectConnection)->table('redirects', function (Blueprint $table): void {
+                $table->string('source', 2048)->change();
+                $table->string('source_md5')->index()->after('source');
+                $table->string('destination', 2048)->change();
+            });
+
+            RedirectModel::each(function (RedirectModel $redirect) {
+                $redirect->update(['source_md5' => md5($redirect->source)]);
+            });
+
+            $this->console()->info('Increased url column size in redirects table.');
+
+            return;
+        }
+
+        Artisan::call('vendor:publish', [
+            '--tag' => 'statamic-redirect-redirect-migrations',
+        ]);
+
+        $this->console()->info('New migration for Redirects published, make sure to run it!');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -94,6 +94,9 @@ class TestCase extends OrchestraTestCase
 
         include_once __DIR__ . '/../database/migrations/create_redirect_error_tables.php.stub';
         (new \CreateRedirectErrorTables())->up();
+
+        include_once __DIR__ . '/../database/migrations/increase_redirect_error_table_url_length.php.stub';
+        (new \IncreaseRedirectErrorTableUrlLength())->up();
     }
 
     /**


### PR DESCRIPTION
# Description
Since some of our redirects contain some large query parameters, we would like the URL field limit to be increased to 2048 characters (this is a generally agreed upon limit, although no exact limit has been defined nor enforced).

Since column indexes only work for columns up to 255 characters, I have added an additional MD5 hashed column.
Since a MD5 hash is always 32 characters long, this can be indexed and should be decently unique.
I have adjusted the queries to use this new indexed column, so the speed of these queries should be similar to how they were.
The queries will still ensure the actual URL matches, since there is still a chance for different URLs to have the same MD5 hash.

I also noticed that when publishing the migrations of the plugin, they are ordered alphabetically, which does not run properly (since adding a description column to the `redirects` table happens before the `redirects` table even exists).
So I have also adjusted this so that it adds a single second to the timestamp of the migrations that should be run after the original tables are created (including these new migrations), making it easier to use the plugin.