### PR TITLE
fix: correctly handle site property as string when exporting

### DIFF
--- a/src/Exporters/CsvExporter.php
+++ b/src/Exporters/CsvExporter.php
@@ -59,7 +59,7 @@ class CsvExporter extends Exporter
         $data = Redirect::all()->map(function (\Rias\StatamicRedirect\Data\Redirect $redirect) {
             $redirectData = $redirect->fileData();
             $redirectData['site'] = $redirect->site()
-                ? $redirect->site()->handle
+                ? $redirect->site()
                 : null;
 
             unset($redirectData['id']);

--- a/src/Exporters/JsonExporter.php
+++ b/src/Exporters/JsonExporter.php
@@ -19,7 +19,7 @@ class JsonExporter extends Exporter
         $submissions = Redirect::all()->map(function (\Rias\StatamicRedirect\Data\Redirect $redirect) {
             $redirectData = $redirect->fileData();
             $redirectData['site'] = $redirect->site()
-                ? $redirect->site()->handle
+                ? $redirect->site()
                 : null;
 
             unset($redirectData['id']);


### PR DESCRIPTION
This pull request ensures that the `$request->site()` value is handled as a string (the site handle), rather than as a `Site` object.

As shown in the implementation:
- [`$site` is stored as a string handle](https://github.com/riasvdv/statamic-redirect/blob/76e2b9d122c79aefbf1b0b38fccfbaa6a64450c9/src/Data/Redirect.php#L40-L41)
- [`$site` is the string handle of a Statamic Site](https://github.com/riasvdv/statamic-redirect/blob/main/src/Data/Redirect.php#L100)

Fixes #216
