### PR TITLE
fix: use correct connection

### DIFF
--- a/src/RedirectServiceProvider.php
+++ b/src/RedirectServiceProvider.php
@@ -219,6 +219,10 @@ class RedirectServiceProvider extends AddonServiceProvider
             $this->createSqliteConnection();
         }
 
+        if ($connection === 'default') {
+            $connection = DB::getDefaultConnection();
+        }
+
         if (Schema::connection($connection)->hasTable('redirects')) {
             return $this;
         }


### PR DESCRIPTION
This PR fixes an issue introduced in v3.11.0, specifically [here](https://github.com/riasvdv/statamic-redirect/compare/3.10.9...3.11.0#diff-802a33958365588abd4286e73c391a97caaa15986538101b4b488e86b05ed125R222).

In the config file there is the following:

```php
/*
 * The database connection used to store redirects. By
 * default this is the included 'stache' connection.
 * Use 'default' to use the Laravel default.
 */
'redirect_connection' => 'default',
```

With the latest changes, `default` will be used as follows:

```php
Schema::connection('default')->hasTable('redirects')
```

which leads to the following error:

```bash
Database connection [default] not configured.
```

The fix in this PR sets `$connection` to the default connection value, in case the config variable is set to `default`.