### PR TITLE
Feat: allow custom model option

### DIFF
--- a/config/redirect.php
+++ b/config/redirect.php
@@ -7,6 +7,11 @@ return [
     'enable' => env('REDIRECT_ENABLED', true),
 
     /**
+     * The model to use for redirects
+     */
+    'model' => \Rias\StatamicRedirect\Eloquent\Redirects\RedirectModel::class,
+
+    /**
      * Whether Redirect should automatically run database migrations or not
      */
     'run_migrations' => env('REDIRECT_RUN_MIGRATIONS', true),

--- a/src/Eloquent/Redirects/RedirectRepository.php
+++ b/src/Eloquent/Redirects/RedirectRepository.php
@@ -95,7 +95,8 @@ class RedirectRepository implements RepositoryContract
 
     public function query()
     {
-        return new RedirectQueryBuilder(RedirectModel::query());
+        $modelClass = config('statamic.redirect.model');
+        return new RedirectQueryBuilder($modelClass::query());
     }
 
     public function make(): Redirect
@@ -132,7 +133,9 @@ class RedirectRepository implements RepositoryContract
             'description' => $redirect->description(),
         ];
 
-        $model = RedirectModel::firstOrNew(['id' => $redirect->id()], $properties);
+        $modelClass = config('statamic.redirect.model');
+
+        $model = $modelClass::firstOrNew(['id' => $redirect->id()], $properties);
 
         if ($model->exists) {
             $model->fill($properties);

--- a/src/UpdateScripts/IncreaseUrlSizeOnRedirects.php
+++ b/src/UpdateScripts/IncreaseUrlSizeOnRedirects.php
@@ -66,7 +66,9 @@ class IncreaseUrlSizeOnRedirects extends UpdateScript
                 $table->string('destination', 2048)->change();
             });
 
-            RedirectModel::each(function (RedirectModel $redirect) {
+            $modelClass = config('statamic.redirect.model');
+
+            $modelClass::each(function (RedirectModel $redirect) {
                 $redirect->update(['source_md5' => md5($redirect->source)]);
             });
 


### PR DESCRIPTION
This allows devs to set a custom model, useful for various events and hooks such as boot(). 

Similar to how Eloquent Driver in Statamic allows this.