### PR TITLE
Prevent database connection during boot when running migrations is disabled

### DIFF
--- a/src/RedirectServiceProvider.php
+++ b/src/RedirectServiceProvider.php
@@ -251,7 +251,7 @@ class RedirectServiceProvider extends AddonServiceProvider
         }
 
         if (config('statamic.redirect.run_migrations')
-            && !Schema::connection($connection)->hasTable('redirects')
+            && ! Schema::connection($connection)->hasTable('redirects')
         ) {
             $defaultConnection = DB::getDefaultConnection();
             DB::setDefaultConnection($connection);


### PR DESCRIPTION
In our CI we are running into an issue that the boot of this package is trying to connect to the database, even when running migrations is disabled.
It seems to me like there is a table check that was accidentally left outside the logic, so I changed this appropriately.