### PR TITLE
Fix duplicate route name causing LogicException on route:cache

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -45,8 +45,7 @@ Route::prefix('redirect')->name('redirect.')->group(function () {
         Route::post('actions/run/list', [RedirectActionController::class, 'bulkActions'])->name('actions.bulk');
 
         Route::get('/{id}', [RedirectController::class, 'edit'])->name('edit');
-        Route::post('/{id}', [RedirectController::class, 'update'])->name('update');
-        Route::patch('/{id}', [RedirectController::class, 'update'])->name('update');
+        Route::match(['post', 'patch'], '/{id}', [RedirectController::class, 'update'])->name('update');
         Route::delete('/{id}', [RedirectController::class, 'destroy'])->name('delete');
     });
 });

--- a/tests/Feature/RouteCacheTest.php
+++ b/tests/Feature/RouteCacheTest.php
@@ -1,0 +1,22 @@
+<?php
+
+it('does not have duplicate route names', function () {
+    // Regression test for https://github.com/riasvdv/statamic-redirect/issues/259
+    // Previously, both POST and PATCH /{id} routes were named 'update',
+    // causing a LogicException when running route:cache.
+
+    $routes = app('router')->getRoutes();
+    $names = collect($routes->getRoutesByName())
+        ->keys()
+        ->filter(fn (string $name) => str_starts_with($name, 'statamic.cp.redirect.'));
+
+    expect($names)->not->toBeEmpty();
+    expect($names->duplicates())->toBeEmpty();
+
+    $updateRoute = collect($routes->getRoutes())
+        ->first(fn ($route) => str_contains($route->getName() ?? '', 'redirect.redirects.update'));
+
+    expect($updateRoute)->not->toBeNull();
+    expect($updateRoute->methods())->toContain('POST');
+    expect($updateRoute->methods())->toContain('PATCH');
+});


### PR DESCRIPTION
## Summary

Fixes #259

- Replaced separate `Route::post()` and `Route::patch()` for `/{id}` with `Route::match(['post', 'patch'], ...)` to eliminate the duplicate `update` route name that caused a `LogicException` when running `php artisan route:cache`
- Added regression test verifying no duplicate route names exist and that the update route accepts both POST and PATCH methods