### PR TITLE
Fix route:list failing when Statamic API is disabled

### DIFF
--- a/src/Http/Controllers/Api/RedirectsController.php
+++ b/src/Http/Controllers/Api/RedirectsController.php
@@ -9,11 +9,6 @@ use Rias\StatamicRedirect\Http\Resources\Api\RedirectResource;
 
 class RedirectsController extends Controller
 {
-    public function __construct()
-    {
-        abort_unless(config('statamic.api.enabled'), 404);
-    }
-
     public function index(Request $request)
     {
         $query = Redirect::query();

--- a/src/RedirectServiceProvider.php
+++ b/src/RedirectServiceProvider.php
@@ -371,6 +371,10 @@ class RedirectServiceProvider extends AddonServiceProvider
 
     protected function bootApi(): self
     {
+        if (! config('statamic.api.enabled')) {
+            return $this;
+        }
+
         Route::middleware(config('statamic.api.middleware', []))
             ->prefix(config('statamic.api.route', 'api'))
             ->group(__DIR__.'/../routes/api.php');


### PR DESCRIPTION
## Problem

Running `php artisan route:list` fails with a 404 abort when `statamic.api.enabled` is `false` (the default).

This happens because the API routes are registered unconditionally in `bootApi()`, and the `RedirectsController` constructor calls `abort_unless(config('statamic.api.enabled'), 404)`. When Laravel resolves the controller during route listing, it triggers the abort.

## Solution

Move the `api.enabled` check from the controller constructor to the route registration in `bootApi()`, matching Statamic's own approach for its API routes. When the API is disabled, the routes are simply never registered — no controller instantiation, no abort.

**Changes:**
- `src/RedirectServiceProvider.php`: Guard `bootApi()` with an early return when `statamic.api.enabled` is false
- `src/Http/Controllers/Api/RedirectsController.php`: Remove the now-redundant `abort_unless` constructor

Fixes #262