### PR TITLE
Fix IncreaseUrlSizeOnErrors crashing when database is unavailable

### DIFF
--- a/src/UpdateScripts/IncreaseUrlSizeOnErrors.php
+++ b/src/UpdateScripts/IncreaseUrlSizeOnErrors.php
@@ -2,6 +2,7 @@
 
 namespace Rias\StatamicRedirect\UpdateScripts;
 
+use Illuminate\Database\QueryException;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schema;
@@ -18,7 +19,11 @@ class IncreaseUrlSizeOnErrors extends UpdateScript
             $errorConnection = config('database.default');
         }
 
-        return ! Schema::connection($errorConnection)->hasColumn('errors', 'url_md5');
+        try {
+            return ! Schema::connection($errorConnection)->hasColumn('errors', 'url_md5');
+        } catch (QueryException) {
+            return false;
+        }
     }
 
     public function update()


### PR DESCRIPTION
- Wrap Schema::connection()->hasColumn() in shouldUpdate() with a try-catch for QueryException
- When the database connection is unavailable (e.g. no DB configured, log_errors set to false), statamic:install no longer crashes with Database connection [redirect-sqlite] not configured
- Matches the existing pattern already used in IncreaseUrlSizeOnRedirects

Closes https://github.com/riasvdv/statamic-redirect/issues/218