### PR TITLE
Fix redirects listing crash when destination_entry is null

### DIFF
--- a/src/Http/Resources/ListedRedirect.php
+++ b/src/Http/Resources/ListedRedirect.php
@@ -28,7 +28,7 @@ class ListedRedirect extends JsonResource
             'source' => $redirect->source(),
             'destination_type' => $redirect->destination_type(),
             'destination' => $redirect->destination(),
-            'destination_entry' => [$redirect->destination_entry()],
+            'destination_entry' => array_filter([$redirect->destination_entry()]),
             'type' => [$redirect->type()],
             'match_type' => [$redirect->matchType()],
             'site' => $redirect->site(),


### PR DESCRIPTION
Filter out null values from the destination_entry array in ListedRedirect resource using array_filter(), so URL-type redirects return [] instead of [null]. This prevents the relationship fieldtype renderer from crashing when accessing .id on null items.

Closes https://github.com/riasvdv/statamic-redirect/issues/265