### PR TITLE
Fix redirect Stache unserialization on Redis cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
         "ext-json": "*",
         "php": "^8.3",
         "spatie/simple-excel": "^1.0|^2.0|^3.0",
-        "statamic/cms": "^v6.0.0",
+        "statamic/cms": "^v6.10.0",
         "doctrine/dbal": "^4.2"
     },
     "require-dev": {

--- a/src/RedirectServiceProvider.php
+++ b/src/RedirectServiceProvider.php
@@ -12,6 +12,7 @@ use Rias\StatamicRedirect\Actions\Delete;
 use Rias\StatamicRedirect\Actions\Export;
 use Rias\StatamicRedirect\Commands\CleanErrorsCommand;
 use Rias\StatamicRedirect\Contracts\RedirectRepository;
+use Rias\StatamicRedirect\Data\Redirect;
 use Rias\StatamicRedirect\Eloquent\Redirects\RedirectRepository as EloquentRedirectRepository;
 use Rias\StatamicRedirect\Events\RedirectSaved;
 use Rias\StatamicRedirect\GraphQL\RedirectQuery;
@@ -104,6 +105,9 @@ class RedirectServiceProvider extends AddonServiceProvider
     public function register()
     {
         $this->registerAddonConfig();
+        $this->registerSerializableClasses([
+            Redirect::class,
+        ]);
 
         $this->app->singleton(RedirectRepository::class, function () {
             return $this->app->get($this->getRedirectRepository());


### PR DESCRIPTION
## Summary
- require `statamic/cms` `^v6.10.0` so this addon can use Statamic's serializable class registration support
- register `Rias\StatamicRedirect\Data\Redirect` via `AddonServiceProvider::registerSerializableClasses()`
- fix the Redis cache / restricted unserialize path behind issue #282

## Testing
- `./vendor/bin/pest tests/Feature/RouteCacheTest.php tests/Feature/RedirectMigrationPublishTest.php`