### PR TITLE
Fix long error URL logging

### DIFF
--- a/src/Data/Error.php
+++ b/src/Data/Error.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Error extends Model
 {
+    public const MAX_URL_LENGTH = 2048;
+
     protected $guarded = [];
 
     protected $casts = [
@@ -38,8 +40,13 @@ class Error extends Model
     protected static function booted()
     {
         self::saving(function ($model) {
+            if ($model->isDirty('url')) {
+                $model->url = self::normalizeUrl($model->url);
+            }
+
             $model->url_md5 = md5($model->url);
         });
+
         self::deleting(function ($error) {
             $error->hits()->delete();
         });
@@ -73,6 +80,13 @@ class Error extends Model
 
     public static function findByUrl(string $url): ?self
     {
+        $url = self::normalizeUrl($url);
+
         return self::where('url_md5', md5($url))->where('url', $url)->first();
+    }
+
+    public static function normalizeUrl(string $url): string
+    {
+        return mb_substr($url, 0, self::MAX_URL_LENGTH, 'UTF-8');
     }
 }

--- a/tests/Feature/Middleware/HandleNotFoundTest.php
+++ b/tests/Feature/Middleware/HandleNotFoundTest.php
@@ -65,6 +65,21 @@ it('creates an error when the response is 404 and saves metadata', function () {
     });
 });
 
+it('truncates long error urls before logging them', function () {
+    $url = '/'.str_repeat('a', Error::MAX_URL_LENGTH + 100);
+
+    $response = $this->middleware->handle(Request::create($url), function () {
+        return new Response('', 404);
+    });
+
+    $error = Error::query()->first();
+
+    expect($response->status())->toEqual(404);
+    expect(Error::query()->count())->toEqual(1);
+    expect(strlen($error->url))->toEqual(Error::MAX_URL_LENGTH);
+    expect(Error::findByUrl($url)->is($error))->toBeTrue();
+});
+
 it('redirects and sets handled if a redirect is found', function (string $source, string $destination, string $requestUrl, string $result) {
     Redirect::make()
         ->source($source)


### PR DESCRIPTION
### Description
Truncate logged error URLs to the existing 2048-character errors.url limit before persisting and lookups, preventing long 404 requests from causing database truncation errors.

### Related issues
Fixes #301