### PR TITLE
Fix redirects with trailing slash and query string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "scripts": {
         "lint": "php-cs-fixer fix --verbose --dry-run --diff",
         "lint:fix": "php-cs-fixer fix --verbose --diff",
-        "test": "phpunit",
+        "test": "pest",
         "test:coverage": "phpdbg -qrr vendor/bin/phpunit --color --coverage-html tests/_reports"
     },
     "minimum-stability": "dev",

--- a/src/Http/Middleware/HandleNotFound.php
+++ b/src/Http/Middleware/HandleNotFound.php
@@ -29,7 +29,10 @@ class HandleNotFound
 
         try {
             $site = Site::findByUrl($request->url()) ?? Site::default();
-            $uri = $request->getRequestUri();
+            $requestUri = $request->getRequestUri();
+            $hasQueryString = str_contains($requestUri, '?');
+            $queryString = $hasQueryString ? Str::after($requestUri, '?') : null;
+            $uri = Str::before($requestUri, '?');
 
             // Remove site URI
             $siteUri = Str::after($site->url(), '/');
@@ -41,6 +44,10 @@ class HandleNotFound
             // Make sure we remove any trailing slash
             $uri = Str::chopEnd($uri, '/');
 
+            if ($hasQueryString) {
+                $uri = "{$uri}?{$queryString}";
+            }
+
             $logErrors = config('statamic.redirect.log_errors', true);
 
             if ($logErrors) {
@@ -48,7 +55,9 @@ class HandleNotFound
                 CleanErrorsJob::dispatchIf(config('statamic.redirect.clean_errors_on_save'));
             }
 
-            $this->cachedRedirects = Cache::get('statamic.redirect.redirects', []);
+            $this->cachedRedirects = $hasQueryString
+                ? []
+                : Cache::get('statamic.redirect.redirects', []);
 
             if (isset($this->cachedRedirects[$site->handle()][$uri])) {
                 $this->markRedirectUsed($this->cachedRedirects[$site->handle()][$uri]['id']);
@@ -77,7 +86,9 @@ class HandleNotFound
 
             $this->markRedirectUsed($redirect->id());
 
-            $this->cacheNewRedirect($site, $redirect, $uri);
+            if (! $hasQueryString) {
+                $this->cacheNewRedirect($site, $redirect, $uri);
+            }
 
             if ($logErrors) {
                 $this->markErrorHandled($error, $redirect->destination());

--- a/tests/Feature/Middleware/HandleNotFoundTest.php
+++ b/tests/Feature/Middleware/HandleNotFoundTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\Test;
@@ -356,6 +357,55 @@ it('handles if the source has a trailing slash', function () {
     });
 
     expect($response->isRedirect(url('/bar')))->toBeTrue();
+});
+
+it('matches an exact redirect when a trailing slash precedes a query string', function () {
+    Redirect::make()
+        ->source('/foo')
+        ->destination('/bar')
+        ->matchType(MatchTypeEnum::EXACT)
+        ->save();
+
+    $response = $this->middleware->handle(Request::create('/foo/?utm_source=x'), function () {
+        return new Response('', 404);
+    });
+
+    expect($response->isRedirect(url('/bar')))->toBeTrue();
+});
+
+it('keeps the query string when normalizing a trailing slash', function () {
+    Redirect::make()
+        ->source('/foo?lang=nl')
+        ->destination('/nl')
+        ->matchType(MatchTypeEnum::EXACT)
+        ->save();
+
+    $response = $this->middleware->handle(Request::create('/foo/?lang=nl'), function () {
+        return new Response('', 404);
+    });
+
+    expect($response->isRedirect(url('/nl')))->toBeTrue();
+});
+
+it('does not cache redirects requested with query strings', function () {
+    Cache::forget('statamic.redirect.redirects');
+
+    Redirect::make()
+        ->source('/foo')
+        ->destination('/bar')
+        ->matchType(MatchTypeEnum::EXACT)
+        ->save();
+
+    $firstResponse = $this->middleware->handle(Request::create('/foo?utm_source=one'), function () {
+        return new Response('', 404);
+    });
+    $secondResponse = $this->middleware->handle(Request::create('/foo?utm_source=two'), function () {
+        return new Response('', 404);
+    });
+
+    expect($firstResponse->isRedirect(url('/bar')))->toBeTrue()
+        ->and($secondResponse->isRedirect(url('/bar')))->toBeTrue()
+        ->and(Cache::get('statamic.redirect.redirects', []))->toBe([]);
 });
 
 it('cleans if config is set to clean', function () {


### PR DESCRIPTION
### Description

Normalize trailing slashes before reattaching query strings, preserve query-aware redirect matching, and skip caching query-string requests to prevent unbounded cache growth.

### Related issues

Fixes #314