### PR TITLE
Fix cross-site redirect destinations

### DIFF
--- a/src/Http/Middleware/HandleNotFound.php
+++ b/src/Http/Middleware/HandleNotFound.php
@@ -165,7 +165,7 @@ class HandleNotFound
     /**
      * @param  \Rias\StatamicRedirect\Data\Redirect  $redirect
      */
-    private function cacheNewRedirect(\Statamic\Sites\Site $site, RedirectContract $redirect, string $url): void
+    private function cacheNewRedirect(StatamicSite $site, RedirectContract $redirect, string $url): void
     {
         $this->cachedRedirects[$site->handle()][$url] = [
             'id' => $redirect->id(),

--- a/src/Http/Middleware/HandleNotFound.php
+++ b/src/Http/Middleware/HandleNotFound.php
@@ -12,6 +12,7 @@ use Rias\StatamicRedirect\Exceptions\GoneHttpException;
 use Rias\StatamicRedirect\Facades\Redirect;
 use Rias\StatamicRedirect\Jobs\CleanErrorsJob;
 use Statamic\Facades\Site;
+use Statamic\Sites\Site as StatamicSite;
 use Statamic\Support\Str;
 
 class HandleNotFound
@@ -175,7 +176,7 @@ class HandleNotFound
         Cache::put('statamic.redirect.redirects', $this->cachedRedirects);
     }
 
-    private function prependSitePrefix(\Statamic\Sites\Site $site, string $destination): string
+    private function prependSitePrefix(StatamicSite $site, string $destination): string
     {
         if (Str::startsWith($destination, ['http://', 'https://'])) {
             return $destination;
@@ -187,7 +188,15 @@ class HandleNotFound
             return $destination;
         }
 
-        if (Str::startsWith($destination, $siteUrl.'/') || $destination === $siteUrl) {
+        $hasSitePrefix = Site::all()->contains(function (StatamicSite $site) use ($destination) {
+            $siteUrl = rtrim($site->url(), '/');
+
+            return ! empty($siteUrl)
+                && $siteUrl !== '/'
+                && (Str::startsWith($destination, $siteUrl.'/') || $destination === $siteUrl);
+        });
+
+        if ($hasSitePrefix) {
             return $destination;
         }
 

--- a/tests/Feature/Middleware/HandleNotFoundTest.php
+++ b/tests/Feature/Middleware/HandleNotFoundTest.php
@@ -537,6 +537,33 @@ it('does not double-prefix the destination when it already includes the site pre
     expect($response->isRedirect(url('/nl/new-page')))->toBeTrue();
 });
 
+it('does not prefix a destination for another site', function () {
+    Site::setSites([
+        'de' => [
+            'name' => 'German',
+            'url' => '/de/',
+            'locale' => 'de_DE',
+        ],
+        'fr' => [
+            'name' => 'French',
+            'url' => '/fr/',
+            'locale' => 'fr_FR',
+        ],
+    ]);
+
+    Redirect::make()
+        ->site('de')
+        ->source('/test-redirect')
+        ->destination('/fr/target-page')
+        ->save();
+
+    $response = $this->middleware->handle(Request::create('/de/test-redirect'), function () {
+        return new Response('', 404);
+    });
+
+    expect($response->isRedirect(url('/fr/target-page')))->toBeTrue();
+});
+
 it('does not prefix external URLs in multisite', function () {
     Site::setSites([
         'default' => [


### PR DESCRIPTION
## Summary

- recognise destination prefixes from every configured site
- preserve the current site prefix behaviour for site-relative destinations
- add a regression test for a DE-to-FR redirect

Fixes #321