### PR TITLE
Fix migration conflicts on application connections

### DIFF
--- a/src/RedirectServiceProvider.php
+++ b/src/RedirectServiceProvider.php
@@ -258,9 +258,11 @@ class RedirectServiceProvider extends AddonServiceProvider
             return $this;
         }
 
-        if ($this->generalConnectionIsBuiltinSqlite()) {
-            $this->createSqliteConnection();
+        if ($connection !== 'redirect-sqlite' && ! $this->generalConnectionIsBuiltinSqlite()) {
+            return $this;
         }
+
+        $this->createSqliteConnection();
 
         if ($connection === 'default') {
             $connection = DB::getDefaultConnection();

--- a/tests/Feature/RedirectMigrationPublishTest.php
+++ b/tests/Feature/RedirectMigrationPublishTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
 use Rias\StatamicRedirect\RedirectServiceProvider;
 
 it('reuses existing redirect migration filenames when publishing', function () {
@@ -23,8 +24,7 @@ it('reuses existing redirect migration filenames when publishing', function () {
             File::put($migration, '<?php');
         }
 
-        $provider = new class($this->app) extends RedirectServiceProvider
-        {
+        $provider = new class($this->app) extends RedirectServiceProvider {
             public function resolveMigrationPath(string $migrationFileName, int $timestampOffset = 0): string
             {
                 return $this->migrationPath($migrationFileName, $timestampOffset);
@@ -38,5 +38,25 @@ it('reuses existing redirect migration filenames when publishing', function () {
     } finally {
         File::deleteDirectory($isolatedDatabasePath);
         $this->app->useDatabasePath($originalDatabasePath);
+    }
+});
+
+it('leaves migrations on application connections to Laravel', function () {
+    config()->set('statamic.redirect.redirect_connection', 'default');
+    config()->set('statamic.redirect.run_migrations', true);
+
+    $provider = new class($this->app) extends RedirectServiceProvider {
+        public function bootRedirectsForTest(): void
+        {
+            $this->bootRedirects();
+        }
+    };
+
+    try {
+        $provider->bootRedirectsForTest();
+
+        expect(Schema::hasTable('redirects'))->toBeFalse();
+    } finally {
+        Schema::dropIfExists('redirects');
     }
 });

--- a/tests/Feature/RedirectMigrationPublishTest.php
+++ b/tests/Feature/RedirectMigrationPublishTest.php
@@ -24,7 +24,8 @@ it('reuses existing redirect migration filenames when publishing', function () {
             File::put($migration, '<?php');
         }
 
-        $provider = new class($this->app) extends RedirectServiceProvider {
+        $provider = new class($this->app) extends RedirectServiceProvider
+        {
             public function resolveMigrationPath(string $migrationFileName, int $timestampOffset = 0): string
             {
                 return $this->migrationPath($migrationFileName, $timestampOffset);
@@ -45,7 +46,8 @@ it('leaves migrations on application connections to Laravel', function () {
     config()->set('statamic.redirect.redirect_connection', 'default');
     config()->set('statamic.redirect.run_migrations', true);
 
-    $provider = new class($this->app) extends RedirectServiceProvider {
+    $provider = new class($this->app) extends RedirectServiceProvider
+    {
         public function bootRedirectsForTest(): void
         {
             $this->bootRedirects();


### PR DESCRIPTION
## Summary

- limit automatic redirect migrations to the built-in SQLite connection
- leave default and custom connections to Laravel migration tracking
- add a regression test for provider boot behavior

Fixes #326

## Tests

- `composer test` (97 tests, 304 assertions)
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --diff src/RedirectServiceProvider.php tests/Feature/RedirectMigrationPublishTest.php`